### PR TITLE
Custom font server doesn't load via corporate network

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,5 @@
-import { Inter } from "next/font/google";
 import { ThemeProvider } from "./providers";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: 'Kibitz',
@@ -22,7 +19,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <link rel="icon" href={`${PATH_PREFIX}/favicon.svg`} type="image/svg" />
       </head>
-      <body className={`${inter.className} bg-background min-h-screen`}>
+      <body className={`bg-background min-h-screen`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a799ff30-95da-4b3f-88eb-c6d7b130f1db)

```
⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa0ZL7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa0ZL7W0Q5n-wU.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7W0Q5nw-s.p.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7W0Q5nw.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1pL7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1pL7W0Q5n-wU.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7W0Q5n-wU.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2JL7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2JL7W0Q5n-wU.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2ZL7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2ZL7W0Q5n-wU.woff2.


 ⚠ [next]/internal/font/google/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2pL7W0Q5n_wU-s.woff2
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.gstatic.com/s/inter/v18/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa2pL7W0Q5n-wU.woff2.
```

Context: https://stackoverflow.com/a/75476382

(Corporate VPN) may not be the target market for kibitz, but this change lets it initially load for me.  About to give it a try, thanks for building!