### PR TITLE
Generic message and tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "lucide-react": "^0.469.0",
         "next": "15.1.3",
         "next-themes": "^0.4.4",
+        "openai": "^4.80.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.1",
@@ -5821,6 +5822,51 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.80.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.80.1.tgz",
+      "integrity": "sha512-+6+bbXFwbIE88foZsBEt36bPkgZPdyFN82clAXG61gnHb2gXdZApDyRrcAHqEtpYICywpqaNo57kOm9dtnb7Cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.74",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+      "integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/typography": "^0.5.15",
+        "@types/lodash": "^4.17.14",
         "@types/node": "^20.17.11",
         "@types/react": "^19.0.2",
         "@types/react-dom": "^19.0.2",
@@ -1560,6 +1561,13 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/typography": "^0.5.15",
+    "@types/lodash": "^4.17.14",
     "@types/node": "^20.17.11",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.469.0",
     "next": "15.1.3",
     "next-themes": "^0.4.4",
+    "openai": "^4.80.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.1",

--- a/src/components/LlmChat/AdminView/ToolsView.tsx
+++ b/src/components/LlmChat/AdminView/ToolsView.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useStore } from '@/stores/rootStore';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Server } from 'lucide-react';
+
+const ToolsView = () => {
+  const { servers } = useStore();
+
+  return (
+    <div className="space-y-4 p-4">
+      <h2 className="text-xl font-bold mb-4">Available Tools</h2>
+      
+      {servers.length === 0 ? (
+        <Alert>
+          <AlertDescription>
+            No MCP servers connected. Tools will appear here when servers connect.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        servers.map((server) => (
+          <Card key={server.id} className="mb-4">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Server className={`h-5 w-5 ${
+                  server.status === 'connected' ? 'text-green-500' : 
+                  server.status === 'connecting' ? 'text-yellow-500' : 
+                  'text-red-500'
+                }`} />
+                <CardTitle>{server.name}</CardTitle>
+              </div>
+              <CardDescription>
+                {server.uri} - {server.status}
+                {server.error && <span className="text-red-500"> ({server.error})</span>}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!server.tools || server.tools.length === 0 ? (
+                <p className="text-muted-foreground">No tools available from this server</p>
+              ) : (
+                <div className="space-y-4">
+                  {server.tools.map((tool) => (
+                    <div key={tool.name} className="border rounded-lg p-4">
+                      <h3 className="font-semibold mb-2">{tool.name}</h3>
+                      <p className="text-sm text-muted-foreground mb-2">{tool.description}</p>
+                      
+                      {tool.input_schema && (
+                        <div className="mt-2">
+                          <h4 className="text-sm font-medium mb-1">Input Schema:</h4>
+                          <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">
+                            {JSON.stringify(tool.input_schema, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default ToolsView;

--- a/src/components/LlmChat/AdminView/ToolsView.tsx
+++ b/src/components/LlmChat/AdminView/ToolsView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Card,
   CardContent,
@@ -8,10 +8,11 @@ import {
 } from '@/components/ui/card';
 import { useStore } from '@/stores/rootStore';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Server } from 'lucide-react';
+import { Server, ChevronRight } from 'lucide-react';
 
 const ToolsView = () => {
   const { servers } = useStore();
+  const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
 
   return (
     <div className="space-y-4 p-4">
@@ -46,16 +47,38 @@ const ToolsView = () => {
               ) : (
                 <div className="space-y-4">
                   {server.tools.map((tool) => (
-                    <div key={tool.name} className="border rounded-lg p-4">
-                      <h3 className="font-semibold mb-2">{tool.name}</h3>
-                      <p className="text-sm text-muted-foreground mb-2">{tool.description}</p>
+                    <div key={tool.name} className="border rounded-lg">
+                      <button
+                        onClick={() => {
+                          setExpandedTools(prev => ({
+                            ...prev,
+                            [tool.name]: !prev[tool.name]
+                          }));
+                        }}
+                        className="w-full p-4 flex items-center justify-between hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex items-center gap-2">
+                          <ChevronRight 
+                            className={`h-4 w-4 transition-transform ${
+                              expandedTools[tool.name] ? 'transform rotate-90' : ''
+                            }`}
+                          />
+                          <h3 className="font-semibold">{tool.name}</h3>
+                        </div>
+                      </button>
                       
-                      {tool.input_schema && (
-                        <div className="mt-2">
-                          <h4 className="text-sm font-medium mb-1">Input Schema:</h4>
-                          <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">
-                            {JSON.stringify(tool.input_schema, null, 2)}
-                          </pre>
+                      {expandedTools[tool.name] && (
+                        <div className="px-4 pb-4">
+                          <p className="text-sm text-muted-foreground mb-2">{tool.description}</p>
+                          
+                          {tool.input_schema && (
+                            <div className="mt-2">
+                              <h4 className="text-sm font-medium mb-1">Input Schema:</h4>
+                              <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">
+                                {JSON.stringify(tool.input_schema, null, 2)}
+                              </pre>
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -37,7 +37,7 @@ export const AdminView = () => {
         mcpServerIds: activeServerIds
       });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeProjectId, servers]);
 
 
@@ -105,16 +105,6 @@ export const AdminView = () => {
               </select>
             </div>
 
-            {(activeProject.settings.provider === 'openrouter' || activeProject.settings.provider === 'openai') && (
-              <Alert>
-                <AlertDescription>
-                  {activeProject.settings.provider === 'openrouter'
-                    ? "OpenRouter support is coming soon. Please use Anthropic for now."
-                    : "OpenAI support is coming soon. Please use Anthropic for now."}
-                </AlertDescription>
-              </Alert>
-            )}
-
             <div>
               <label className="block text-sm font-medium mb-1">
                 API Key <span className="text-red-500">*</span>
@@ -122,7 +112,7 @@ export const AdminView = () => {
               <p className="text-sm text-muted-foreground mb-2">
                 Required to chat. Get yours at{' '}
                 {(() => {
-                  switch(activeProject.settings.provider) {
+                  switch (activeProject.settings.provider) {
                     case 'openrouter':
                       return (
                         <a href="https://openrouter.ai/keys" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
@@ -150,12 +140,12 @@ export const AdminView = () => {
                   activeProject.settings.provider === 'openrouter'
                     ? activeProject.settings.openRouterApiKey || ''
                     : activeProject.settings.provider === 'openai'
-                    ? activeProject.settings.openaiApiKey || ''
-                    : activeProject.settings.anthropicApiKey || activeProject.settings.apiKey || ''  // Fallback for backward compatibility
+                      ? activeProject.settings.openaiApiKey || ''
+                      : activeProject.settings.anthropicApiKey || activeProject.settings.apiKey || ''  // Fallback for backward compatibility
                 }
                 onChange={(e) => {
                   const value = e.target.value.trim();
-                  switch(activeProject.settings.provider) {
+                  switch (activeProject.settings.provider) {
                     case 'openrouter':
                       handleSettingsChange({
                         openRouterApiKey: value
@@ -177,17 +167,17 @@ export const AdminView = () => {
                   activeProject.settings.provider === 'openrouter'
                     ? "⚠️ OpenRouter support coming soon"
                     : activeProject.settings.provider === 'openai'
-                    ? "⚠️ OpenAI support coming soon"
-                    : "⚠️ Enter your Anthropic API key to use the chat"
+                      ? "⚠️ Enter your OpenAI API key to use the chat"
+                      : "⚠️ Enter your Anthropic API key to use the chat"
                 }
                 className={
                   activeProject.settings.provider === 'openrouter'
                     ? ""
                     : (!activeProject.settings.anthropicApiKey?.trim() && !activeProject.settings.apiKey?.trim())
-                    ? "border-red-500 dark:border-red-400 placeholder:text-red-500/90 dark:placeholder:text-red-400/90 placeholder:font-medium"
-                    : ""
+                      ? "border-red-500 dark:border-red-400 placeholder:text-red-500/90 dark:placeholder:text-red-400/90 placeholder:font-medium"
+                      : ""
                 }
-                disabled={activeProject.settings.provider === 'openrouter' || activeProject.settings.provider === 'openai'}
+                disabled={activeProject.settings.provider === 'openrouter'}
               />
             </div>
 

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -12,6 +12,7 @@ import { getProviderModels } from '../types/provider';
 import { McpConfiguration } from './McpConfiguration';
 import { ThemeToggle } from '../ThemeToggle';
 import { useStore } from '@/stores/rootStore';
+import { getDefaultModelForProvider } from '@/stores/rootStore';
 
 export const AdminView = () => {
   const { projects, activeProjectId, updateProjectSettings, servers } = useStore();
@@ -50,6 +51,7 @@ export const AdminView = () => {
   }
 
   const handleSettingsChange = (settings: Partial<ProjectSettings>) => {
+    console.log("handleSettingsChange - settings received:", settings);
     // Special handling for provider changes to preserve API keys
     if (settings.provider !== undefined && settings.provider !== activeProject.settings.provider) {
       // When changing provider, ensure we preserve both API keys
@@ -63,7 +65,9 @@ export const AdminView = () => {
           // Keep legacy apiKey in sync with anthropicApiKey
           apiKey: settings.provider === 'anthropic'
             ? (activeProject.settings.anthropicApiKey || activeProject.settings.apiKey)
-            : activeProject.settings.apiKey
+            : activeProject.settings.apiKey,
+          // **[FIX] Update model to default for new provider**
+          model: getDefaultModelForProvider(settings.provider)
         }
       });
     } else {
@@ -210,9 +214,12 @@ export const AdminView = () => {
               </label>
               <select
                 value={activeProject.settings.model}
-                onChange={(e) => handleSettingsChange({
-                  model: e.target.value
-                })}
+                onChange={(e) => {
+                  console.log("Model dropdown onChange event:", e.target.value);
+                  handleSettingsChange({
+                    model: e.target.value
+                  });
+                }}
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               >
                 {getProviderModels(activeProject.settings.provider || 'anthropic').map(model => (

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -7,9 +7,11 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ProjectSettings, ProviderType } from '../context/types';
 import { getProviderModels } from '../types/provider';
 import { McpConfiguration } from './McpConfiguration';
+import ToolsView from './ToolsView';
 import { ThemeToggle } from '../ThemeToggle';
 import { useStore } from '@/stores/rootStore';
 import { getDefaultModelForProvider } from '@/stores/rootStore';
@@ -17,6 +19,7 @@ import { getDefaultModelForProvider } from '@/stores/rootStore';
 export const AdminView = () => {
   const { projects, activeProjectId, updateProjectSettings, servers } = useStore();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [activeTab, setActiveTab] = useState('config');
 
   const activeProject = projects.find(p => p.id === activeProjectId);
 
@@ -88,7 +91,21 @@ export const AdminView = () => {
         <ThemeToggle />
       </div>
 
-      <Card>
+      <div className="mb-6">
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList>
+            <TabsTrigger value="config">Configuration</TabsTrigger>
+            <TabsTrigger value="tools">Tools</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {activeTab === 'tools' ? (
+        <ToolsView />
+      ) : (
+
+        <>
+          <Card>
         <CardContent className="p-6">
           <h3 className="text-lg font-medium mb-4">API Settings</h3>
           <div className="space-y-4">
@@ -317,6 +334,8 @@ export const AdminView = () => {
           </AlertDialog>
         </CardContent>
       </Card>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -5,9 +5,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ProjectSettings, ProviderType } from '../context/types';
 import { getProviderModels } from '../types/provider';
 import { McpConfiguration } from './McpConfiguration';
@@ -121,7 +120,7 @@ export const AdminView = () => {
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               >
                 <option value="anthropic">Anthropic (Claude)</option>
-                <option value="openrouter">OpenRouter (Coming Soon)</option>
+                <option value="openrouter">OpenRouter</option>
                 <option value="openai">OpenAI</option>
               </select>
             </div>
@@ -185,10 +184,10 @@ export const AdminView = () => {
                   }
                 }}
                 placeholder={
-                  activeProject.settings.provider === 'openrouter'
-                    ? "⚠️ OpenRouter support coming soon"
-                    : activeProject.settings.provider === 'openai'
-                      ? "⚠️ Enter your OpenAI API key to use the chat"
+                  activeProject.settings.provider === 'openai'
+                    ? "⚠️ Enter your OpenAI API key to use the chat"
+                    : activeProject.settings.provider === 'openrouter'
+                      ? "⚠️ Enter your OpenRouter API key to use the chat"
                       : "⚠️ Enter your Anthropic API key to use the chat"
                 }
                 className={
@@ -198,7 +197,6 @@ export const AdminView = () => {
                       ? "border-red-500 dark:border-red-400 placeholder:text-red-500/90 dark:placeholder:text-red-400/90 placeholder:font-medium"
                       : ""
                 }
-                disabled={activeProject.settings.provider === 'openrouter'}
               />
             </div>
 

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -263,6 +263,36 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
         },
       ] as TextBlockParam[] : undefined;
 
+      // **[Existing] Get current conversation history as GenericMessage[]**
+      const currentGenericMessages: GenericMessage[] = (activeConversation?.messages || []).map(m => ({
+        role: m.role as 'user' | 'assistant' | 'system', // Ensure role is correctly typed
+        content: m.content,
+      }));
+
+      // **[Existing] Create user message as GenericMessage**
+      const userGenericMessage: GenericMessage = {
+        role: 'user',
+        content: userMessageContent,
+      };
+
+      // **[Existing] Combine current history with new user message in GenericMessage format**
+      const updatedGenericMessages = [...currentGenericMessages, userGenericMessage];
+
+      console.log("Current activeProject.settings.provider:", activeProject.settings.provider);
+
+      let apiFormatMessages;
+      const provider = activeProject.settings.provider;
+      if (provider === 'openai') {
+        apiFormatMessages = toOpenAIFormat(updatedGenericMessages);
+        console.log("Sending OpenAI formatted messages:", apiFormatMessages);
+      } else { // Default to anthropic
+        apiFormatMessages = toAnthropicFormat(
+          updatedGenericMessages,
+          systemPrompt
+        );
+        console.log("Sending Anthropic formatted messages:", apiFormatMessages);
+      }
+
       while (true) {
         const cachedApiMessages = currentMessages.filter((message, index, array) => {
           // Process messages and remove incomplete tool use interactions

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -270,7 +270,6 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
       console.log("Current activeProject.settings:", activeProject.settings); // Log settings object itself
       if (activeProject.settings) { // Check if settings exists before accessing properties
         console.log("typeof activeProject.settings.provider:", typeof activeProject.settings.provider); // Check type
-        console.log("Keys in activeProject.settings:", Object.keys(activeProject.settings)); // Log keys
       } else {
         console.log("activeProject.settings is UNDEFINED");
       }

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -456,7 +456,7 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
         const genericMessagesToSend: GenericMessage[] = apiMessagesToSend.map(msg => ({
           role: msg.role,
           content: msg.content,
-          name: msg.toolInput // If you need to pass tool input as 'name' in generic format
+          name: msg.toolInput as string | undefined // If you need to pass tool input as 'name' in generic format, ensure type matches GenericMessage
         }));
 
         const anthropicApiMessages = toAnthropicFormat(

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -266,13 +266,6 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
       // **[ADD LOGGING for activeProject OBJECT]**
       console.log("Current activeProject:", activeProject);
 
-      // **[ADD MORE DETAILED LOGGING]**
-      console.log("Current activeProject.settings:", activeProject.settings); // Log settings object itself
-      if (activeProject.settings) { // Check if settings exists before accessing properties
-      } else {
-        console.log("activeProject.settings is UNDEFINED");
-      }
-
       // **[FIX] Use provider from providerConfig.type instead of settings.provider**
       const provider = activeProject.settings.providerConfig?.type;
       console.log("Using provider from providerConfig:", provider);

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -269,7 +269,6 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
       // **[ADD MORE DETAILED LOGGING]**
       console.log("Current activeProject.settings:", activeProject.settings); // Log settings object itself
       if (activeProject.settings) { // Check if settings exists before accessing properties
-        console.log("typeof activeProject.settings.provider:", typeof activeProject.settings.provider); // Check type
       } else {
         console.log("activeProject.settings is UNDEFINED");
       }

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -1,29 +1,15 @@
-import React, { useEffect, useState, useRef, useCallback, useImperativeHandle } from 'react';
-import Image from 'next/image';
-import { Anthropic } from '@anthropic-ai/sdk';
-import OpenAI from 'openai';
-import { Tool, CacheControlEphemeral, TextBlockParam } from '@anthropic-ai/sdk/resources/messages/messages';
-import { Send, Square, X, ChevronDown } from 'lucide-react';
-import type { MessageCreateParams } from '@anthropic-ai/sdk/resources/messages/messages';
-import { FileUpload } from './FileUpload';
-import { Button } from '@/components/ui/button';
-import { CopyButton } from '@/components/ui/copy';
-import { Textarea } from '@/components/ui/textarea';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { Message, MessageContent, ImageMessageContent, DocumentMessageContent } from './types';
-import { wakeLock } from '@/lib/wakeLock';
-import { ToolCallModal } from './ToolCallModal';
-import { VoiceRecorder } from './VoiceRecorder';
+import React, { useState, useRef, useImperativeHandle } from 'react';
+import { Spinner } from '@/components/ui/spinner';
 import { useFocusControl } from './context/useFocusControl';
 import { useStore } from '@/stores/rootStore';
-import { Spinner } from '@/components/ui/spinner';
-import { throttle } from 'lodash';
-import { GenericMessage, toAnthropicFormat, toOpenAIFormat } from '@/components/LlmChat/types/genericMessage';
-import { FunctionCall } from 'openai/resources/chat/completions';
-
-const DEFAULT_MODEL = 'claude-3-5-sonnet-20241022';
+import { Message, MessageContent } from './types';
+import { ToolCallModal } from './ToolCallModal';
+import { MessageContentRenderer } from './components/MessageContent';
+import { FileContentList } from './components/FileContentList';
+import { ChatInput } from './components/ChatInput';
+import { ScrollToBottomButton } from './components/ScrollToBottomButton';
+import { useMessageSender } from './hooks/useMessageSender';
+import { useScrollControl } from './hooks/useScrollControl';
 
 export interface ChatViewRef {
   focus: () => void;
@@ -31,15 +17,17 @@ export interface ChatViewRef {
 
 const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
   const [currentFileContent, setCurrentFileContent] = useState<MessageContent[]>([]);
-  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [inputMessage, setInputMessage] = useState('');
+  const [selectedToolCall, setSelectedToolCall] = useState<{
+    name: string;
+    input: Record<string, unknown>;
+    result: string | null;
+  } | null>(null);
+
   const {
     projects,
     activeProjectId,
     activeConversationId,
-    updateProjectSettings,
-    renameConversation,
-    servers,
-    executeTool
   } = useStore();
 
   const activeProject = projects.find(p => p.id === activeProjectId);
@@ -47,23 +35,16 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
     c => c.id === activeConversationId
   );
 
-  const [inputMessage, setInputMessage] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const shouldCancelRef = useRef<boolean>(false);
-  const streamRef = useRef<{ abort: () => void } | null>(null);
-  const chatContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const [selectedToolCall, setSelectedToolCall] = useState<{
-    name: string;
-    input: Record<string, unknown>;
-    result: string | null;
-  } | null>(null);
 
-  // Use the focus control hook for managing conversation focus
+  // Use custom hooks
   useFocusControl();
+  const { isLoading, error, handleSendMessage, cancelCurrentCall } = useMessageSender();
+  const { chatContainerRef, isAtBottom, scrollToBottom } = useScrollControl({
+    messages: activeConversation?.messages || []
+  });
 
-  // Expose the focus method to parent components
+  // Expose focus method to parent components
   useImperativeHandle(
     ref,
     () => ({
@@ -76,1025 +57,57 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
     []
   );
 
-  // Focus input when opening a new chat or when a chat is selected
-  useEffect(() => {
-    if (inputRef.current && activeConversation) {
-      inputRef.current.focus();
-    }
-  }, [activeConversation]);
-
-  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
-  // Scroll handling logic
-  useEffect(() => {
-    const makeHandleScroll = async () => {
-      while (!chatContainerRef.current) {
-        console.log(`no chatContainerRef`);
-        await sleep(250);
-      }
-      console.log(`got chatContainerRef`);
-      const container = chatContainerRef.current;
-
-      // Only force scroll on initial load
-      if (container.scrollTop === 0) {
-        container.scrollTop = container.scrollHeight;
-      }
-
-      // Add scroll event listener
-      const handleScroll = throttle(() => {
-        const { scrollTop, scrollHeight, clientHeight } = container;
-        const bottom = container.scrollHeight < container.clientHeight || Math.abs(scrollHeight - clientHeight - scrollTop) < 50;
-        setIsAtBottom(bottom);
-      }, 100);
-
-      // Check initial scroll position
-      handleScroll();
-
-      container.addEventListener('scroll', handleScroll);
-      return () => container.removeEventListener('scroll', handleScroll);
-    };
-
-    makeHandleScroll();
-  }, []);
-
-  // Handle message updates
-  useEffect(() => {
-    if (!chatContainerRef.current || !activeConversation?.messages.length) {
-      return;
-    }
-
-    const lastMessage = activeConversation.messages[activeConversation.messages.length - 1];
-
-    // Only scroll to bottom if already at bottom or if it's the first message
-    const isInitialMessage = activeConversation.messages.length <= 1;
-    if ((lastMessage.role === 'assistant' || lastMessage.role === 'user') && (isAtBottom || isInitialMessage)) {
-      requestAnimationFrame(() => {
-        const container = chatContainerRef.current;
-        if (container) {
-          container.scrollTop = container.scrollHeight;
-        }
-      });
-    }
-  }, [activeConversation?.messages, activeConversation?.lastUpdated, isAtBottom]);
-
-  const scrollToBottom = useCallback(() => {
-    const container = chatContainerRef.current;
-    if (container) {
-      container.scrollTop = container.scrollHeight;
-    }
-  }, []);
-
-  const getUniqueTools = (should_cache: boolean) => {
-    if (!activeProject?.settings.mcpServerIds?.length) {
-      return [];
-    }
-
-    const toolMap = new Map<string, Tool>();
-
-    servers
-      .filter(server =>
-        activeProject.settings.mcpServerIds.includes(server.id)
-      )
-      .flatMap(s => s.tools || [])
-      .forEach((tool: Tool) => {
-        if (!toolMap.has(tool.name)) {
-          toolMap.set(tool.name, {
-            name: tool.name,
-            description: tool.description,
-            input_schema: tool.input_schema
-          });
-        }
-      });
-
-    const tools = Array.from(toolMap.values());
-    return !should_cache ? tools : tools.map((t, index, array) => index != array.length - 1 ? t : { ...t, cache_control: { type: 'ephemeral' } as CacheControlEphemeral });
-  };
-
-  const updateConversationMessages = (projectId: string, conversationId: string, newMessages: Message[]) => {
-    // Find the current conversation to preserve its properties
-    const currentConversation = activeProject?.conversations.find(c => c.id === conversationId);
-    if (!currentConversation) return;
-
-    updateProjectSettings(projectId, {
-      conversations: activeProject!.conversations.map(conv =>
-        conv.id === conversationId
-          ? {
-            ...currentConversation, // Preserve all existing properties including name
-            messages: newMessages,
-            lastUpdated: new Date()
-          }
-          : conv
-      )
-    });
-  };
-
-  const cancelCurrentCall = useCallback(() => {
-    shouldCancelRef.current = true;
-    if (streamRef.current) {
-      streamRef.current.abort();
-    }
-    setIsLoading(false);
-    setError('Operation cancelled');
-  }, []);
-
-  const handleSendMessage = async () => {
-    shouldCancelRef.current = false;
-    if ((!inputMessage.trim() && currentFileContent.length === 0) || !activeProject || !activeConversationId) return;
-
-    // Reset any previous error and show loading state
-    setError(null);
-    setIsLoading(true);
-
-    const currentApiKey = activeProject.settings.provider === 'openrouter'
-      ? activeProject.settings.openRouterApiKey
-      : (activeProject.settings.anthropicApiKey || activeProject.settings.apiKey);  // Fallback for backward compatibility
-
-    if (!currentApiKey?.trim()) {
-      setError(`API key not found. Please set your ${activeProject.settings.provider === 'openrouter' ? 'OpenRouter' : 'Anthropic'} API key in the Settings panel.`);
-      setIsLoading(false);
-      return;
-    }
-    // Reset the textarea height immediately after sending
-    if (inputRef.current) {
-      inputRef.current.style.height = '2.5em';
-    }
-
-    await wakeLock.acquire();
-    try {
-      const userMessageContent: MessageContent[] = currentFileContent.map(c =>
-        c.type === 'image' ? { ...c, fileName: undefined } : { ...c, fileName: undefined }
+  const getToolResult = (toolUseIndex: number, toolId: string) => {
+    const nextMessage = activeConversation?.messages[toolUseIndex + 1];
+    let toolResult = null;
+    if (nextMessage && Array.isArray(nextMessage.content)) {
+      const resultContent = nextMessage.content.find(c =>
+        c.type === 'tool_result' && c.tool_use_id === toolId
       );
-
-      if (inputMessage.trim()) {
-        userMessageContent.push({
-          type: 'text' as const,
-          text: inputMessage,
-        });
-      }
-
-      const userMessage: Message = {
-        role: 'user',
-        content: userMessageContent,
-        timestamp: new Date()
-      };
-
-      const currentMessages = [...(activeConversation?.messages || []), userMessage];
-      updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
-      setInputMessage('');
-      setCurrentFileContent([]);
-
-      // retry enough times to always push past 60s (the rate limit timer):
-      //  https://github.com/anthropics/anthropic-sdk-typescript/blob/dc2591fcc8847d509760a61777fc1b79e0eab646/src/core.ts#L645
-      const anthropic = new Anthropic({
-        apiKey: activeProject.settings.anthropicApiKey || activeProject.settings.apiKey || '',  // Use anthropic key only
-        dangerouslyAllowBrowser: true,
-        maxRetries: 12,
-      });
-
-      const savedToolResults = new Set<string>();
-
-      const toolsCached = getUniqueTools(true);
-      const tools = getUniqueTools(false);
-
-      // Only include system content if there is a non-empty system prompt
-      const systemPrompt = activeProject.settings.systemPrompt?.trim();
-      const systemPromptContent = systemPrompt ? [
-        {
-          type: "text",
-          text: systemPrompt,
-        },
-      ] as TextBlockParam[] : undefined;
-
-      // **[LOG PROVIDER]**
-      console.log("Using provider:", activeProject.settings.provider);
-
-      // **[Existing] Get current conversation history as GenericMessage[]**
-      const currentGenericMessages: GenericMessage[] = (activeConversation?.messages || []).map(m => ({
-        role: m.role as 'user' | 'assistant' | 'system', // Ensure role is correctly typed
-        content: m.content,
-      }));
-
-      // **[Existing] Create user message as GenericMessage**
-      const userGenericMessage: GenericMessage = {
-        role: 'user',
-        content: userMessageContent,
-      };
-
-      // **[Existing] Combine current history with new user message in GenericMessage format**
-      const updatedGenericMessages = [...currentGenericMessages, userGenericMessage];
-
-      let apiFormatMessages;
-      if (activeProject.settings.provider === 'openai') {
-        apiFormatMessages = toOpenAIFormat(updatedGenericMessages, toolsCached);
-      } else if (activeProject.settings.provider === 'anthropic') {
-        apiFormatMessages = toAnthropicFormat(updatedGenericMessages);
-      } else {
-        console.warn("Unknown provider:", activeProject.settings.provider);
-        apiFormatMessages = toAnthropicFormat(updatedGenericMessages); // Default to anthropic just in case, or handle error
-      }
-      console.log("handleSendMessage: API formatted messages:", apiFormatMessages); // **[LOGGING]**
-
-      while (true) {
-        const cachedApiMessages = currentMessages.filter((message, index, array) => {
-          // Process messages and remove incomplete tool use interactions
-          // If content is a string, keep it
-          if (typeof message.content === 'string') return true;
-
-          // At this point we know message.content is an array
-          const messageContent = message.content as MessageContent[];
-
-          // Check if this message has a tool_use
-          const hasToolUse = messageContent.some(c => c.type === 'tool_use');
-          if (!hasToolUse) return true;
-
-          // Look for matching tool_result in next message
-          const nextMessage = array[index + 1];
-          if (!nextMessage) return false;
-
-          // If next message has string content, can't have tool_result
-          if (typeof nextMessage.content === 'string') return false;
-
-          const nextMessageContent = nextMessage.content as MessageContent[];
-
-          // Check if any tool_use in current message has matching tool_result in next message
-          return messageContent.every(content => {
-            if (content.type !== 'tool_use') return true;
-            if (!('id' in content)) return true; // Skip if no id present
-            const toolId = content.id;
-            return nextMessageContent.some(
-              nextContent =>
-                nextContent.type === 'tool_result' &&
-                'tool_use_id' in nextContent &&
-                nextContent.tool_use_id === toolId
-            );
-          });
-        })
-          .map((m, index, array) =>
-            index < array.length - 3 ?
-              {
-                role: m.role,
-                content: m.content,
-                toolInput: m.toolInput ? m.toolInput : undefined,
-              } :
-              {
-                role: m.role,
-                content: (typeof m.content === 'string' ?
-                  [{ type: 'text' as const, text: m.content, cache_control: { type: 'ephemeral' } as CacheControlEphemeral }]
-                  : m.content.map((c, index, array) =>
-                    index != array.length - 1 ? c :
-                      {
-                        ...c,
-                        cache_control: { type: 'ephemeral' } as CacheControlEphemeral,
-                      }
-                  )) as MessageContent[],
-                toolInput: m.toolInput ? m.toolInput : undefined,
-              }
-          );
-
-        const newestToolResultId = currentMessages
-          .filter((msg): msg is Message & { content: MessageContent[] } =>
-            Array.isArray(msg.content)
-          )
-          .flatMap(msg => msg.content)
-          .filter((content): content is MessageContent & { tool_use_id: string } =>
-            'tool_use_id' in content && content.type === 'tool_result'
-          )
-          .map(content => content.tool_use_id)
-          .pop();
-
-        if (activeProject.settings.elideToolResults) {
-          if ((cachedApiMessages[cachedApiMessages.length - 1].content as MessageContent[])[0].type === 'tool_result') {
-            const keepToolResponse = await anthropic.messages.create({
-              model: DEFAULT_MODEL,
-              max_tokens: 8192,
-              messages: [
-                cachedApiMessages.filter(msg => {
-                  if (!Array.isArray(msg.content)) return false;
-                  const toolResult = msg.content.find(c =>
-                    c.type === 'tool_use' || c.type === 'tool_result'
-                  );
-                  return toolResult;
-                }).map(msg =>
-                  !(msg.content as MessageContent[]).find(c => c.type === 'tool_result') ?
-                    {
-                      ...msg,
-                      content: [
-                        msg.content[0],
-                        {
-                          type: 'text' as const,
-                          text: `${JSON.stringify(msg.content[1])}`,
-                        },
-                      ],
-                    } :
-                    {
-                      ...msg,
-                      content: [
-                        {
-                          type: 'text' as const,
-                          text: `${JSON.stringify({ ...(msg.content as MessageContent[])[0], content: 'elided' })}`,
-                        },
-                      ],
-                    }
-                ),
-                {
-                  role: 'user' as const,
-                  content: [{
-                    type: 'text' as const,
-                    text: 'Rate each `message`: will the `type: tool_result` be required by `assistant` to serve the next response? Reply ONLY with `<tool_use_id>: Yes` or `<tool_use_id>: No` for each tool_result. DO NOT reply with code, prose, or commentary of any kind.\nExample output:\ntoolu_014huykAonadokihkrboFfqn: Yes\ntoolu_01APhxfkQZ1nT7Ayt8Vtyuz8: Yes\ntoolu_01PcgSwHbHinNrn3kdFaD82w: No\ntoolu_018Qosa8PHAZjUa312TXRwou: Yes',
-                    cache_control: { type: 'ephemeral' } as CacheControlEphemeral,
-                  }],
-                },
-              ] as Message[],
-              system: [{
-                type: 'text' as const,
-                text: 'Rate each `message`: will the `type: tool_result` be required by `assistant` to serve the next response? Reply ONLY with `<tool_use_id>: Yes` or `<tool_use_id>: No` for each tool_result. DO NOT reply with code, prose, or commentary of any kind.\nExample output:\ntoolu_014huykAonadokihkrboFfqn: Yes\ntoolu_01APhxfkQZ1nT7Ayt8Vtyuz8: Yes\ntoolu_01PcgSwHbHinNrn3kdFaD82w: No\ntoolu_018Qosa8PHAZjUa312TXRwou: Yes',
-                cache_control: { type: 'ephemeral' } as CacheControlEphemeral,
-              }],
-            });
-
-            if (keepToolResponse.content[0].type === 'text') {
-              console.log('a');
-              const lines = keepToolResponse.content[0].text.split('\n');
-
-              for (const line of lines) {
-                const [key, value] = line.split(': ');
-
-                if (value.trim() === 'Yes') {
-                  console.log('b');
-                  savedToolResults.add(key);
-                } else if (value.trim() === 'No') {
-                  console.log('c');
-                  savedToolResults.delete(key);
-                }
-              }
-            }
-            console.log(`keepToolResponse: ${JSON.stringify(keepToolResponse)}\n${JSON.stringify(savedToolResults)}`);
-          }
-        }
-
-        const apiMessagesToSend = !activeProject.settings.elideToolResults ? cachedApiMessages :
-          cachedApiMessages
-            .map(msg => {
-              if (!Array.isArray(msg.content)) return msg;
-
-              const toolResult = msg.content.find(c =>
-                c.type === 'tool_result'
-              );
-              if (!toolResult) return msg;
-
-              const toolUseId = (toolResult as { tool_use_id: string }).tool_use_id;
-              return toolUseId === newestToolResultId || savedToolResults.has(toolUseId) ?
-                msg :
-                {
-                  ...msg,
-                  content: [{
-                    ...msg.content[0],
-                    content: 'elided',
-                  }],
-                };
-            });
-
-        const genericMessagesToSend: GenericMessage[] = apiMessagesToSend.map(msg => ({
-          role: msg.role,
-          content: msg.content,
-          name: msg.toolInput as string | undefined // If you need to pass tool input as 'name' in generic format, ensure type matches GenericMessage
-        }));
-
-        const anthropicApiMessages = toAnthropicFormat(
-          genericMessagesToSend,
-          systemPrompt // Pass system prompt separately for Anthropic format
-        );
-
-        const currentStreamMessage = {
-          role: 'assistant' as const,
-          content: [] as MessageContent[],
-          timestamp: new Date(),
-        };
-
-        const textContent: MessageContent = {
-          type: 'text',
-          text: '',
-        };
-        currentStreamMessage.content.push(textContent);
-
-        // Helper function to handle stream with retries
-        const streamWithRetry = async (params: MessageCreateParams) => {
-          let lastError: unknown;
-          for (let attempt = 0; attempt < 12; attempt++) { // Try for 1 minute (12 * 5 seconds)
-            try {
-              const stream = await anthropic.messages.stream(params);
-              return stream;
-            } catch (error) {
-              lastError = error;
-              // Check if error has overloaded_error type
-              if (typeof error === 'object' && error !== null) {
-                const errorObj = error as { error?: { type?: string }; status?: number };
-                const isOverloaded = errorObj.error?.type === 'overloaded_error' || errorObj.status === 429;
-                if (isOverloaded && attempt < 11) { // Don't wait on last attempt
-                  await new Promise(resolve => setTimeout(resolve, 5000)); // Wait 5 seconds
-                  continue;
-                }
-              }
-              throw error; // Throw non-overloaded errors immediately
-            }
-          }
-          throw lastError; // Throw last error if all retries failed
-        };
-
-        let stream;
-        if (activeProject.settings.provider === 'openai') {
-          // **[START OpenAI API CALL IMPLEMENTATION]**
-          const openai = new OpenAI({ // Initialize OpenAI client
-            apiKey: activeProject.settings.openaiApiKey, // Use OpenAI API key
-            dangerouslyAllowBrowser: true, // Allow browser usage (with caution!)
-          });
-
-          try {
-            stream = await openai.chat.completions.create({ // Make OpenAI API stream call
-              model: activeProject.settings.model || 'gpt-4o', // Or your default OpenAI model
-              messages: apiFormatMessages.messages, // Use OpenAI formatted messages
-              functions: apiFormatMessages.functions, // Include functions for OpenAI
-
-              // **[LOG JSON STRINGIFIED API FORMAT MESSAGES]**
-              stream: true,
-              max_tokens: 8192,
-            });
-
-            let functionCallBuffer: FunctionCall | null = null;
-
-            for await (const chunk of stream) {
-              const content = chunk?.choices?.[0]?.delta?.content || "";
-              const functionCallDelta = chunk?.choices?.[0]?.delta?.function_call;
-
-              if (content) {
-                textContent.text += content;
-              }
-
-              if (functionCallDelta) {
-                if (!functionCallBuffer) {
-                  functionCallBuffer = functionCallDelta;
-                } else {
-                  functionCallBuffer = {
-                    name: functionCallBuffer.name || functionCallDelta.name,
-                    arguments: (functionCallBuffer.arguments || '') + (functionCallDelta.arguments || ''),
-                  };
-                }
-              }
-
-              const updatedMessages = [...currentMessages, currentStreamMessage];
-              updateConversationMessages(activeProject.id, activeConversationId, updatedMessages);
-            }
-
-            if (functionCallBuffer) {
-              const functionName = functionCallBuffer.name;
-              const functionArgs = JSON.parse(functionCallBuffer.arguments || '{}');
-
-              const toolUseContent: MessageContent = {
-                type: 'tool_use',
-                id: `tool_use_${Date.now()}`,
-                name: functionName as string,
-                input: functionArgs,
-              };
-
-              currentStreamMessage.content.push(toolUseContent);
-              updateConversationMessages(activeProject.id, activeConversationId, [...currentMessages, currentStreamMessage]);
-
-              try {
-                const serverWithTool = servers.find(s =>
-                  s.tools?.some(t => t.name === functionName)
-                );
-
-                if (!serverWithTool) {
-                  throw new Error(`No server found for tool ${functionName}`);
-                }
-
-                const result = await executeTool(
-                  serverWithTool.id,
-                  functionName as string,
-                  functionArgs,
-                );
-
-                const toolResultMessage: Message = {
-                  role: 'user', // Tool result is from the user/agent perspective
-                  content: [{
-                    type: 'tool_result',
-                    tool_use_id: toolUseContent.id,
-                    content: result,
-                  }],
-                  timestamp: new Date()
-                };
-
-                const updatedMessagesWithResult = [...currentMessages, currentStreamMessage, toolResultMessage];
-                updateConversationMessages(activeProject.id, activeConversationId, updatedMessagesWithResult);
-
-              } catch (toolError) {
-                const errorMessage: Message = {
-                  role: 'user',
-                  content: [{
-                    type: 'tool_result',
-                    tool_use_id: toolUseContent.id,
-                    content: `Error: ${toolError instanceof Error ? toolError.message : 'Unknown error'}`,
-                    is_error: true,
-                  }],
-                  timestamp: new Date()
-                };
-                const updatedMessagesWithError = [...currentMessages, currentStreamMessage, errorMessage];
-                updateConversationMessages(activeProject.id, activeConversationId, updatedMessagesWithError);
-              } finally {
-                setIsLoading(false);
-                wakeLock.release();
-                return;
-              }
-            }
-
-          } catch (openaiError: any) { // Catch OpenAI errors
-            console.error("OpenAI API error:", openaiError);
-            setError(`OpenAI API error: ${openaiError.message || 'Unknown error'}`);
-          } finally {
-            setIsLoading(false);
-            wakeLock.release();
-            return; // Exit handleSendMessage on error
-          }
-          // **[END OpenAI API CALL IMPLEMENTATION]**
-
-        } else if (activeProject.settings.provider === 'anthropic') {
-          stream = await streamWithRetry({
-            model: activeProject.settings.model || DEFAULT_MODEL,
-            max_tokens: 8192,
-            messages: anthropicApiMessages.messages,
-            ...(anthropicApiMessages.system && { system: anthropicApiMessages.system }),
-            ...(systemPromptContent && systemPromptContent.length > 0 && {
-              system: systemPromptContent
-            }),
-            ...(tools.length > 0 && {
-              tools: toolsCached
-            })
-          });
-          // **[NODE.JS STREAM HANDLING - ANTHROPIC]**
-          stream.on('text', (text) => {
-            textContent.text += text;
-
-            // Update conversation with streaming message
-            const updatedMessages = [...currentMessages, currentStreamMessage];
-            updateConversationMessages(activeProject.id, activeConversationId, updatedMessages);
-          });
-          // **[END NODE.JS STREAM HANDLING - ANTHROPIC]**
-
-          // streamRef.current = stream; // Removed - not needed with new stream handling
-
-          // Break if cancel was requested during setup
-          // if (shouldCancelRef.current) { // Removed - while loop now controls stream reading
-          //   break;
-          // }
-
-          // stream.on('text', (text) => { // **[OLD - NODE.JS STREAM HANDLING - OPENAI]**
-          //   textContent.text += text;
-          //
-          //   // Update conversation with streaming message
-          //   const updatedMessages = [...currentMessages, currentStreamMessage];
-          //   updateConversationMessages(activeProject.id, activeConversationId, updatedMessages);
-          // });
-
-        } else {
-          // Should not reach here as provider is checked earlier
-          setIsLoading(false);
-          wakeLock.release();
-          return;
-        }
-
-        streamRef.current = stream;
-
-        // Break if cancel was requested during setup
-        if (shouldCancelRef.current) {
-          break;
-        }
-
-        // Handle tool use in the final response if any
-        // Filter and validate text content in the final response
-        const finalResponse = await stream.finalMessage();
-
-        // Process content to handle empty text blocks
-        const processedContent = finalResponse.content.map((content: MessageContent) => {
-          if (!content['type']) {
-            return content;
-          }
-          // Keep non-text content
-          if (content.type !== 'text') {
-            return content;
-          }
-
-          // Check if text content is purely whitespace
-          const isWhitespace = content.text.trim().length === 0;
-
-          // If there's only one content block and it's whitespace, replace with "empty"
-          if (isWhitespace && finalResponse.content.length === 1) {
-            return {
-              ...content,
-              text: 'empty',
-            } as MessageContent;
-          }
-          return content;
-        })
-          .filter((content: MessageContent) => {
-            if (!content['type']) {
-              return true;
-            }
-            // Keep non-text content
-            if (content.type !== 'text') {
-              return true;
-            }
-
-            // Check if text content is purely whitespace
-            const isWhitespace = content.text.trim().length === 0;
-
-            // If there's only one content block and it's whitespace, replace with "empty"
-            if (isWhitespace && finalResponse.content.length === 1) {
-              console.log(`got unexpected whitespace case from assistant: ${JSON.stringify(finalResponse)}`);
-              content.text = 'empty';
-              return true;
-            }
-
-            // For multiple content blocks, drop purely whitespace ones
-            return !isWhitespace;
-          });
-
-        const processedResponse = {
-          ...finalResponse,
-          content: processedContent
-        };
-
-        currentMessages.push(processedResponse);
-        updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
-
-        // Only rename if this is a new chat getting its first messages
-        // Get the current conversation state directly from projects
-        const currentConversation = activeProject?.conversations.find(c => c.id === activeConversationId);
-        if (currentConversation && currentMessages.length === 2 && currentConversation.name === '(New Chat)') {
-          // Double check the name hasn't changed while we were processing
-          const latestConversation = activeProject?.conversations.find(c => c.id === activeConversationId);
-          if (latestConversation?.name !== '(New Chat)') {
-            console.log('Title already changed, skipping generation');
-            return;
-          }
-
-          const userFirstMessage = currentMessages[0].content;
-          const assistantFirstMessage = currentMessages[1].content;
-
-          const summaryResponse = await anthropic.messages.create({
-            model: activeProject.settings.model || DEFAULT_MODEL,
-            max_tokens: 20,
-            messages: [{
-              role: "user",
-              content: `Generate a concise, specific title (3-4 words max) that accurately captures the main topic or purpose of this conversation. Use key technical terms when relevant. Avoid generic words like 'conversation', 'chat', or 'help'.
-
-User message: ${JSON.stringify(userFirstMessage)}
-Assistant response: ${Array.isArray(assistantFirstMessage)
-                  ? assistantFirstMessage.filter(c => c.type === 'text').map(c => c.type === 'text' ? c.text : '').join(' ')
-                  : assistantFirstMessage}
-
-Format: Only output the title, no quotes or explanation
-Example good titles:
-- React Router Setup
-- Python Script Optimization
-- Database Schema Design
-- ML Model Training
-- Docker Container Networking`
-            }]
-          });
-
-          const type = summaryResponse.content[0].type;
-          if (type == 'text') {
-            const suggestedTitle = summaryResponse.content[0].text
-              .replace(/["']/g, '')
-              .replace('title:', '')
-              .replace('Title:', '')
-              .replace('title', '')
-              .replace('Title', '')
-              .trim();
-            if (suggestedTitle) {
-              renameConversation(activeProject.id, activeConversationId, suggestedTitle);
-            }
-          }
-        }
-
-        // Check for and handle tool use
-        const toolUseContent = finalResponse.content.find((c: MessageContent) => c.type === 'tool_use');
-        if (toolUseContent && toolUseContent.type === 'tool_use') {
-          try {
-            // Break if cancel was requested before tool execution
-            if (shouldCancelRef.current) {
-              break;
-            }
-
-            const serverWithTool = servers.find(s =>
-              s.tools?.some(t => t.name === toolUseContent.name)
-            );
-
-            if (!serverWithTool) {
-              throw new Error(`No server found for tool ${toolUseContent.name}`);
-            }
-
-            const result = await executeTool(
-              serverWithTool.id,
-              toolUseContent.name,
-              toolUseContent.input as Record<string, unknown>,
-            );
-
-            // Check cancel after tool execution
-            if (shouldCancelRef.current) {
-              break;
-            }
-
-            const toolResultMessage: Message = {
-              role: 'user',
-              content: [{
-                type: 'tool_result',
-                tool_use_id: toolUseContent.id,
-                content: result,
-              }],
-              timestamp: new Date()
-            };
-
-            currentMessages.push(toolResultMessage);
-            updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
-
-            // Continue the conversation with the tool result if not cancelled
-            if (!shouldCancelRef.current) {
-              continue;
-            }
-            break;
-          } catch (error) {
-            const errorMessage: Message = {
-              role: 'user',
-              content: [{
-                type: 'tool_result',
-                tool_use_id: toolUseContent.id,
-                content: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
-                is_error: true,
-              }],
-              timestamp: new Date()
-            };
-
-            currentMessages.push(errorMessage);
-            updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
-          }
-        }
-
-        // Break the loop if no tool use or should cancel
-        if (shouldCancelRef.current || (activeProject.settings.provider === 'anthropic' && !toolUseContent)) {
-          break;
-        }
-      }
-
-    } catch (error) {
-      if (error && typeof error === 'object' && 'message' in error && error.message === 'Request was aborted.') {
-        console.log('Request was cancelled by user');
-      } else if (typeof error === 'object' && error !== null) {
-        // Cast error to object with optional error and status properties
-        const errorObj = error as { error?: { type?: string }; status?: number };
-        const isOverloaded = errorObj.error?.type === 'overloaded_error' || errorObj.status === 429;
-
-        if (isOverloaded) {
-          console.error('Server overloaded, all retries failed:', error);
-          if (!shouldCancelRef.current) {
-            setError('Server is currently overloaded. Message sending failed after multiple retries. Please try again later.');
-          }
-        } else {
-          console.error('Failed to send message:', error);
-          if (!shouldCancelRef.current) {
-            setError(error instanceof Error ? error.message : 'An error occurred');
-          }
-        }
-      } else {
-        console.error('Failed to send message:', error);
-        if (!shouldCancelRef.current) {
-          setError(error instanceof Error ? error.message : 'An error occurred');
-        }
-      }
-    } finally {
-      shouldCancelRef.current = false;
-      setIsLoading(false);
-      streamRef.current = null;
-      await wakeLock.release();
-
-      // Focus the input field and reset height after the LLM finishes talking
-      if (inputRef.current) {
-        inputRef.current.focus();
-        inputRef.current.style.height = '2.5em';
+      if (resultContent && resultContent.type === 'tool_result') {
+        toolResult = resultContent.content;
       }
     }
-  };
+    return toolResult;
+  }
 
-  const renderMessage = (message: Message, index: number) => {
-    if (Array.isArray(message.content)) {
-      return message.content.map((content, contentIndex) => {
-        if (content.type === 'text') {
-          return (
-            <div
-              key={`text-${index}-${contentIndex}`}
-              className={`flex max-w-full pt-6`}
-            >
-              <div className="relative group w-full max-w-full overflow-x-auto">
-                {!content.text.match(/```[\s\S]*```/) && (
-                  <div className="absolute right-2 top-0 z-10">
-                    <CopyButton
-                      text={content.text.trim()}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity"
-                    />
-                  </div>
-                )}
-                <div
-                  className={`w-full max-w-full rounded-lg px-4 py-2 ${message.role === 'user'
-                    ? 'bg-accent !text-accent-foreground'
-                    : 'bg-muted text-foreground'
-                    }`}
-                >
-                  <ReactMarkdown
-                    className={`prose dark:prose-invert break-words max-w-full ${message.role === 'user' ? '[&_p]:!text-accent-foreground [&_code]:!text-accent-foreground' : ''}`}
-                    components={{
-                      p: ({ children }) => (
-                        <p className="break-words whitespace-pre-wrap overflow-hidden">
-                          {children}
-                        </p>
-                      ),
-                      pre({ children, ...props }) {
-                        // Extract text from the code block
-                        const getCodeText = (node: unknown): string => {
-                          if (typeof node === 'string') return node;
-                          if (!node) return '';
-                          if (Array.isArray(node)) {
-                            return node.map(getCodeText).join('\n');
-                          }
-                          if (typeof node === 'object' && node !== null && 'props' in node) {
-                            const element = node as { props?: { className?: string; children?: unknown } };
-                            if (element.props?.className?.includes('language-')) {
-                              return getCodeText(element.props.children);
-                            }
-                            if (element.props?.children) {
-                              return getCodeText(element.props.children);
-                            }
-                          }
-                          return '';
-                        };
-
-                        const text = getCodeText(children).trim();
-
-                        return (
-                          <div className="group/code relative max-w-full">
-                            <div className="absolute top-2 right-2 z-10">
-                              <CopyButton
-                                text={text}
-                                className="opacity-0 group-hover/code:opacity-100 transition-opacity"
-                              />
-                            </div>
-                            <pre className="overflow-x-auto max-w-full whitespace-pre" {...props}>{children}</pre>
-                          </div>
-                        );
-                      },
-                      code({ inline, children, ...props }) {
-                        return inline ? (
-                          <code className="text-inherit whitespace-nowrap inline" {...props}>{children}</code>
-                        ) : (
-                          <code className="block overflow-x-auto whitespace-pre-wrap" {...props}>{children}</code>
-                        );
-                      },
-                      a: ({ href, children }) => (
-                        <a
-                          href={href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                        >
-                          {children}
-                        </a>
-                      ),
-                    }}
-                    remarkPlugins={[remarkGfm]}
-                  >
-                    {content.text}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            </div>
-          );
-        } else if (content.type === 'image') {
-          return (
-            <div
-              key={`image-${index}-${contentIndex}`}
-              className={`flex`}
-            >
-              <div
-                className={`w-full rounded-lg px-4 py-2 ${message.role === 'user'
-                  ? 'bg-accent text-accent-foreground'
-                  : 'bg-muted text-foreground'
-                  }`}
-              >
-                <Image
-                  src={`data:${content.source.media_type};base64,${content.source.data}`}
-                  alt="User uploaded image"
-                  className="max-h-[150px] max-w-[300px] w-auto h-auto rounded object-contain"
-                  width={300}
-                  height={150}
-                />
-              </div>
-            </div>
-          );
-        } else if (content.type === 'document') {
-          return (
-            <div
-              key={`document-${index}-${contentIndex}`}
-              className={`flex`}
-            >
-              <div
-                className={`w-full rounded-lg px-4 py-2 ${message.role === 'user'
-                  ? 'bg-accent text-accent-foreground'
-                  : 'bg-muted text-foreground'
-                  }`}
-              >
-                <embed
-                  src={`data:${content.source.media_type};base64,${content.source.data}`}
-                  type={content.source.media_type}
-                  width="100%"
-                  height="600px"
-                  className="rounded"
-                />
-              </div>
-            </div>
-          );
-        } else if (content.type === 'tool_use') {
-          const nextMessage = activeConversation?.messages[index + 1];
-          let toolResult = null;
-          if (nextMessage && Array.isArray(nextMessage.content)) {
-            const resultContent = nextMessage.content.find(c =>
-              c.type === 'tool_result' && c.tool_use_id === content.id
-            );
-            if (resultContent && resultContent.type === 'tool_result') {
-              toolResult = resultContent.content;
-            }
-          }
-
-          return (
-            <div
-              key={`tool_use-${index}-${contentIndex}`}
-              className={`flex`}
-            >
-              <div
-                key={`message-${index}-content-${contentIndex}`}
-                className={`w-full rounded-lg px-4 py-2 relative group ${message.role === 'user'
-                  ? 'bg-accent text-accent-foreground'
-                  : 'bg-muted text-foreground'
-                  }`}
-              >
-                <button
-                  onClick={() => setSelectedToolCall({
-                    name: content.name,
-                    input: content.input,
-                    result: toolResult
-                  })}
-                  className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline"
-                >
-                  Use tool: {content.name}
-                </button>
-              </div>
-            </div>
-          );
-        }
-        return null;
-      });
+  const renderMessageContent = (message: Message, index: number) => {
+    if (!Array.isArray(message.content)) {
+      return (
+        <MessageContentRenderer
+          key={`string-${index}`}
+          content={{
+            type: 'text',
+            text: message.content as string
+          }}
+          isUserMessage={message.role === 'user'}
+          onToolClick={() => {}}
+          toolResult={null}
+          contentIndex={0}
+          messageIndex={index}
+        />
+      );
     }
 
-    return (
-      <div
-        key={`string-${index}`}
-        className={`flex`}
-      >
-        <div
-          className={`w-full rounded-lg px-4 py-2 ${message.role === 'user'
-            ? 'bg-accent text-accent-foreground'
-            : 'bg-muted text-foreground'
-            }`}
-        >
-          <ReactMarkdown
-            className="prose dark:prose-invert break-words overflow-hidden whitespace-pre-wrap max-w-full"
-            components={{
-              a: ({ href, children }) => (
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                >
-                  {children}
-                </a>
-              )
-            }}
-            remarkPlugins={[remarkGfm]}
-          >
-            {message.content}
-          </ReactMarkdown>
-        </div>
-      </div>
-    );
+    return message.content.map((content, contentIndex) => (
+      <MessageContentRenderer
+        key={`${content.type}-${index}-${contentIndex}`}
+        content={content}
+        isUserMessage={message.role === 'user'}
+        onToolClick={(name: string, input: Record<string, unknown>, result: string | null) => {
+          setSelectedToolCall({ name, input, result });
+        }}
+        toolResult={
+          Array.isArray(message.content) &&
+          typeof message.content[contentIndex] === 'object' &&
+          'type' in message.content[contentIndex] &&
+          message.content[contentIndex].type === 'tool_use' ?
+            getToolResult(index, message.content[contentIndex].id) : null
+        }
+        contentIndex={contentIndex}
+        messageIndex={index}
+      />
+    ));
   };
 
   if (!activeConversation) {
@@ -1105,26 +118,26 @@ Example good titles:
     );
   }
 
+  const handleSubmit = async () => {
+    await handleSendMessage(inputMessage, currentFileContent);
+    setInputMessage('');
+    setCurrentFileContent([]);
+  };
+
   return (
     <div className="flex flex-col h-full relative">
       <div ref={chatContainerRef} className="h-[calc(100vh-4rem)] overflow-y-auto p-4">
         <div className="space-y-4 mb-4">
           {activeConversation.messages.map((message, index) => (
-            renderMessage(message, index)
+            renderMessageContent(message, index)
           ))}
         </div>
       </div>
 
-      {/* Scroll to bottom button */}
-      {!isAtBottom && (
-        <button
-          onClick={scrollToBottom}
-          className="fixed bottom-[60px] right-2 md:right-8 z-[100] bg-primary/70 text-primary-foreground rounded-full p-3 shadow-lg hover:bg-primary/90 transition-all hover:scale-110 animate-in fade-in slide-in-from-right-2"
-          aria-label="Scroll to bottom"
-        >
-          <ChevronDown className="w-6 h-6" />
-        </button>
-      )}
+      <ScrollToBottomButton
+        onClick={scrollToBottom}
+        visible={!isAtBottom}
+      />
 
       {error && (
         <div className="px-4 py-2 text-sm text-red-500">
@@ -1132,97 +145,32 @@ Example good titles:
         </div>
       )}
 
-      {activeProject?.settings.provider === 'openrouter' && (
-        <div className="px-4">
-          <Alert>
-            <AlertDescription>
-              OpenRouter support is coming soon. Please switch to Anthropic provider in settings to chat.
-            </AlertDescription>
-          </Alert>
-        </div>
-      )}
-
       <div className="flex flex-col gap-2 p-2 bg-background fixed bottom-0 left-0 right-0 z-50 md:left-[280px] md:w-[calc(100%-280px)]">
-        {currentFileContent.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {currentFileContent.map((content, index) => (
-              <div key={index} className="flex items-center gap-2 bg-muted rounded px-2 py-1">
-                <span className="text-sm">
-                  {content.type === 'text' ? 'Text file' :
-                    ((content as ImageMessageContent | DocumentMessageContent).fileName || 'Untitled')}
-                </span>
-                <button
-                  onClick={() => {
-                    setCurrentFileContent(prev => prev.filter((_, i) => i !== index));
-                  }}
-                  className="hover:text-destructive"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-        <div className="flex gap-2">
-          <div className="relative flex-1">
-            <Textarea
-              value={inputMessage}
-              onChange={(e) => setInputMessage(e.target.value)}
-              placeholder={
-                activeProject?.settings.provider === 'openrouter'
-                  ? "⚠️ OpenRouter support coming soon"
-                  : !activeProject?.settings.apiKey?.trim()
-                    ? "⚠️ Set your API key in Settings to start chatting"
-                    : isLoading
-                      ? "Processing response..."
-                      : "Type your message"
-              }
-              onKeyDown={(e) => {
-                // Only send on Enter in desktop mode
-                const isMobile = window.matchMedia('(max-width: 768px)').matches;
-                if (e.key === 'Enter' && !e.shiftKey && !isLoading && !isMobile) {
-                  e.preventDefault();
-                  handleSendMessage();
-                }
-              }}
-              ref={inputRef}
-              className={`pr-20 ${!activeProject?.settings.apiKey?.trim() ? "placeholder:text-red-500/90 dark:placeholder:text-red-400/90 placeholder:font-medium" : ""}`}
-              maxRows={8}
-              disabled={isLoading || !activeProject?.settings.apiKey?.trim() || activeProject?.settings.provider === 'openrouter'}
-            />
-            <div className="absolute right-2 bottom-2 flex gap-1">
-              <FileUpload
-                onFileSelect={(content) => {
-                  setCurrentFileContent(prev => [...prev, { ...content }]);
-                }}
-                onUploadComplete={() => {
-                  if (inputRef.current) {
-                    inputRef.current.focus();
-                  }
-                }}
-              />
-              <VoiceRecorder
-                onTranscriptionComplete={(text) => {
-                  setInputMessage(prev => {
-                    const newText = prev.trim() ? `${prev}\n${text}` : text;
-                    return newText;
-                  });
-                }}
-              />
-            </div>
-          </div>
-          <Button
-            onClick={isLoading ? cancelCurrentCall : handleSendMessage}
-            disabled={!activeProjectId || !activeConversationId || activeProject?.settings.provider === 'openrouter'}
-            className="self-end relative"
-          >
-            {isLoading ? (
-              <Square className="w-4 h-4" />
-            ) : (
-              <Send className="w-4 h-4" />
-            )}
-          </Button>
-        </div>
+        <FileContentList
+          files={currentFileContent}
+          onRemove={(index) => {
+            setCurrentFileContent(prev => prev.filter((_, i) => i !== index));
+          }}
+        />
+
+        <ChatInput
+          value={inputMessage}
+          onChange={setInputMessage}
+          onSend={handleSubmit}
+          isLoading={isLoading}
+          onStop={cancelCurrentCall}
+          isDisabled={!activeProjectId || !activeConversationId}
+          onFileSelect={(content) => {
+            setCurrentFileContent(prev => [...prev, { ...content }]);
+          }}
+          placeholder={
+            !activeProject?.settings.apiKey?.trim()
+              ? "⚠️ Set your API key in Settings to start chatting"
+              : isLoading
+                ? "Processing response..."
+                : "Type your message"
+          }
+        />
       </div>
 
       {selectedToolCall && (

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -263,6 +263,22 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
         },
       ] as TextBlockParam[] : undefined;
 
+      // **[ADD LOGGING for activeProject OBJECT]**
+      console.log("Current activeProject:", activeProject);
+
+      // **[ADD MORE DETAILED LOGGING]**
+      console.log("Current activeProject.settings:", activeProject.settings); // Log settings object itself
+      if (activeProject.settings) { // Check if settings exists before accessing properties
+        console.log("typeof activeProject.settings.provider:", typeof activeProject.settings.provider); // Check type
+        console.log("Keys in activeProject.settings:", Object.keys(activeProject.settings)); // Log keys
+      } else {
+        console.log("activeProject.settings is UNDEFINED");
+      }
+
+      // **[FIX] Use provider from providerConfig.type instead of settings.provider**
+      const provider = activeProject.settings.providerConfig?.type;
+      console.log("Using provider from providerConfig:", provider);
+
       // **[Existing] Get current conversation history as GenericMessage[]**
       const currentGenericMessages: GenericMessage[] = (activeConversation?.messages || []).map(m => ({
         role: m.role as 'user' | 'assistant' | 'system', // Ensure role is correctly typed
@@ -278,19 +294,16 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
       // **[Existing] Combine current history with new user message in GenericMessage format**
       const updatedGenericMessages = [...currentGenericMessages, userGenericMessage];
 
-      console.log("Current activeProject.settings.provider:", activeProject.settings.provider);
-
       let apiFormatMessages;
-      const provider = activeProject.settings.provider;
       if (provider === 'openai') {
         apiFormatMessages = toOpenAIFormat(updatedGenericMessages);
         console.log("Sending OpenAI formatted messages:", apiFormatMessages);
-      } else { // Default to anthropic
-        apiFormatMessages = toAnthropicFormat(
-          updatedGenericMessages,
-          systemPrompt
-        );
+      } else if (provider === 'anthropic') {
+        apiFormatMessages = toAnthropicFormat(updatedGenericMessages);
         console.log("Sending Anthropic formatted messages:", apiFormatMessages);
+      } else {
+        console.warn("Unknown provider:", provider);
+        apiFormatMessages = toAnthropicFormat(updatedGenericMessages); // Default to anthropic just in case, or handle error
       }
 
       while (true) {

--- a/src/components/LlmChat/ToolCallModal.tsx
+++ b/src/components/LlmChat/ToolCallModal.tsx
@@ -33,8 +33,8 @@ export const ToolCallModal = ({ toolCall, onClose }: ToolCallModalProps) => {
         </DialogHeader>
 
         <div className={cn(
-          "space-y-4 overflow-hidden flex-grow",
-          isExpanded ? "overflow-y-auto pr-2" : "max-h-[240px] sm:max-h-[280px]"
+          "space-y-4 overflow-hidden flex-grow overflow-y-auto pr-2",
+          isExpanded && "h-[75vh]"
         )}>
           <div>
             <h4 className="font-medium mb-2">Input:</h4>

--- a/src/components/LlmChat/components/ChatInput.tsx
+++ b/src/components/LlmChat/components/ChatInput.tsx
@@ -1,0 +1,90 @@
+import React, { useRef } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { FileUpload } from '../FileUpload';
+import { VoiceRecorder } from '../VoiceRecorder';
+import { Button } from '@/components/ui/button';
+import { Send, Square } from 'lucide-react';
+import { MessageContent } from '../types';
+
+interface ChatInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  onStop?: () => void;
+  isLoading: boolean;
+  isDisabled: boolean;
+  onFileSelect: (content: MessageContent) => void;
+  placeholder?: string;
+}
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+  value,
+  onChange,
+  onSend,
+  onStop,
+  isLoading,
+  isDisabled,
+  onFileSelect,
+  placeholder = "Type your message"
+}) => {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset height when loading starts
+  React.useEffect(() => {
+    if (isLoading && inputRef.current) {
+      inputRef.current.style.height = 'auto';
+    }
+  }, [isLoading]);
+
+  return (
+    <div className="flex gap-2">
+      <div className="relative flex-1">
+        <Textarea
+          value={isLoading ? "Processing..." : value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          readOnly={isLoading}
+          onKeyDown={(e) => {
+            // Only send on Enter in desktop mode
+            const isMobile = window.matchMedia('(max-width: 768px)').matches;
+            if (e.key === 'Enter' && !e.shiftKey && !isLoading && !isMobile) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+          ref={inputRef}
+          className={`pr-20 transition-colors ${isLoading ? 'bg-muted text-muted-foreground resize-none' : ''}`}
+          maxRows={8}
+          disabled={isDisabled || isLoading}
+        />
+        <div className="absolute right-2 bottom-2 flex gap-1">
+          <FileUpload
+            onFileSelect={onFileSelect}
+            onUploadComplete={() => {
+              if (inputRef.current) {
+                inputRef.current.focus();
+              }
+            }}
+          />
+          <VoiceRecorder
+            onTranscriptionComplete={(text) => {
+              const newText = value.trim() ? `${value}\n${text}` : text;
+              onChange(newText);
+            }}
+          />
+        </div>
+      </div>
+      <Button
+        onClick={isLoading ? onStop : onSend}
+        disabled={isDisabled || (isLoading && !onStop)}
+        className={`self-end relative ${isLoading ? 'bg-destructive hover:bg-destructive/90' : ''}`}
+      >
+        {isLoading ? (
+          <Square className="w-4 h-4" />
+        ) : (
+          <Send className="w-4 h-4" />
+        )}
+      </Button>
+    </div>
+  );
+};

--- a/src/components/LlmChat/components/FileContentList.tsx
+++ b/src/components/LlmChat/components/FileContentList.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { MessageContent } from '../types';
+
+interface FileContentListProps {
+  files: MessageContent[];
+  onRemove: (index: number) => void;
+}
+
+export const FileContentList: React.FC<FileContentListProps> = ({ files, onRemove }) => {
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {files.map((content, index) => (
+        <div key={index} className="flex items-center gap-2 bg-muted rounded px-2 py-1">
+          <span className="text-sm">
+            {content.type === 'text' ? 'Text file' : 'fileName' in content ? content.fileName || 'Untitled' : 'Untitled'}
+          </span>
+          <button
+            onClick={() => onRemove(index)}
+            className="hover:text-destructive"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/LlmChat/components/MessageContent.tsx
+++ b/src/components/LlmChat/components/MessageContent.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import Image from 'next/image';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { CopyButton } from '@/components/ui/copy';
+import { MessageContent as MessageContentType } from '../types';
+
+interface MessageContentProps {
+  content: MessageContentType;
+  isUserMessage: boolean;
+  onToolClick?: (name: string, input: Record<string, unknown>, result: string | null) => void;
+  toolResult: string | null;
+  contentIndex: number;
+  messageIndex: number;
+}
+
+export const MessageContentRenderer: React.FC<MessageContentProps> = ({
+  content,
+  isUserMessage,
+  onToolClick,
+  toolResult,
+  contentIndex,
+  messageIndex
+}) => {
+  if (content.type === 'text') {
+    return (
+      <div
+        key={`text-${messageIndex}-${contentIndex}`}
+        className="flex max-w-full pt-6"
+      >
+        <div className="relative group w-full max-w-full overflow-x-auto">
+          {!content.text.match(/```[\s\S]*```/) && (
+            <div className="absolute right-2 top-0 z-10">
+              <CopyButton
+                text={content.text.trim()}
+                className="opacity-0 group-hover:opacity-100 transition-opacity"
+              />
+            </div>
+          )}
+          <div
+            className={`w-full max-w-full rounded-lg px-4 py-2 ${
+              isUserMessage
+                ? 'bg-accent !text-accent-foreground'
+                : 'bg-muted text-foreground'
+            }`}
+          >
+            <ReactMarkdown
+              className={`prose dark:prose-invert break-words max-w-full ${
+                isUserMessage ? '[&_p]:!text-accent-foreground [&_code]:!text-accent-foreground' : ''
+              }`}
+              components={{
+                p: ({ children }) => (
+                  <p className="break-words whitespace-pre-wrap overflow-hidden">
+                    {children}
+                  </p>
+                ),
+                pre({ children, ...props }) {
+                  const getCodeText = (node: unknown): string => {
+                    if (typeof node === 'string') return node;
+                    if (!node) return '';
+                    if (Array.isArray(node)) {
+                      return node.map(getCodeText).join('\n');
+                    }
+                    if (typeof node === 'object' && node !== null && 'props' in node) {
+                      const element = node as { props?: { className?: string; children?: unknown } };
+                      if (element.props?.className?.includes('language-')) {
+                        return getCodeText(element.props.children);
+                      }
+                      if (element.props?.children) {
+                        return getCodeText(element.props.children);
+                      }
+                    }
+                    return '';
+                  };
+
+                  const text = getCodeText(children).trim();
+
+                  return (
+                    <div className="group/code relative max-w-full">
+                      <div className="absolute top-2 right-2 z-10">
+                        <CopyButton
+                          text={text}
+                          className="opacity-0 group-hover/code:opacity-100 transition-opacity"
+                        />
+                      </div>
+                      <pre className="overflow-x-auto max-w-full whitespace-pre" {...props}>
+                        {children}
+                      </pre>
+                    </div>
+                  );
+                },
+                code({ inline, children, ...props }) {
+                  return inline ? (
+                    <code className="text-inherit whitespace-nowrap inline" {...props}>
+                      {children}
+                    </code>
+                  ) : (
+                    <code className="block overflow-x-auto whitespace-pre-wrap" {...props}>
+                      {children}
+                    </code>
+                  );
+                },
+                a: ({ href, children }) => (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    {children}
+                  </a>
+                ),
+              }}
+              remarkPlugins={[remarkGfm]}
+            >
+              {content.text}
+            </ReactMarkdown>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (content.type === 'image') {
+    return (
+      <div
+        key={`image-${messageIndex}-${contentIndex}`}
+        className="flex"
+      >
+        <div
+          className={`w-full rounded-lg px-4 py-2 ${
+            isUserMessage
+              ? 'bg-accent text-accent-foreground'
+              : 'bg-muted text-foreground'
+          }`}
+        >
+          <Image
+            src={`data:${content.source.media_type};base64,${content.source.data}`}
+            alt="User uploaded image"
+            className="max-h-[150px] max-w-[300px] w-auto h-auto rounded object-contain"
+            width={300}
+            height={150}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (content.type === 'document') {
+    return (
+      <div
+        key={`document-${messageIndex}-${contentIndex}`}
+        className="flex"
+      >
+        <div
+          className={`w-full rounded-lg px-4 py-2 ${
+            isUserMessage
+              ? 'bg-accent text-accent-foreground'
+              : 'bg-muted text-foreground'
+          }`}
+        >
+          <embed
+            src={`data:${content.source.media_type};base64,${content.source.data}`}
+            type={content.source.media_type}
+            width="100%"
+            height="600px"
+            className="rounded"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (content.type === 'tool_use') {
+    return (
+      <div
+        key={`tool_use-${messageIndex}-${contentIndex}`}
+        className="flex"
+      >
+        <div
+          className={`w-full rounded-lg px-4 py-2 relative group ${
+            isUserMessage
+              ? 'bg-accent text-accent-foreground'
+              : 'bg-muted text-foreground'
+          }`}
+        >
+          <div className="space-y-2">
+            <button
+              onClick={() => onToolClick?.(content.name, content.input, toolResult)}
+              className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline group"
+            >
+              🛠️: {content.name}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/components/LlmChat/components/ScrollToBottomButton.tsx
+++ b/src/components/LlmChat/components/ScrollToBottomButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface ScrollToBottomButtonProps {
+  onClick: () => void;
+  visible: boolean;
+}
+
+export const ScrollToBottomButton: React.FC<ScrollToBottomButtonProps> = ({
+  onClick,
+  visible
+}) => {
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-[60px] right-2 md:right-8 z-[100] bg-primary/70 text-primary-foreground rounded-full p-3 shadow-lg hover:bg-primary/90 transition-all hover:scale-110 animate-in fade-in slide-in-from-right-2"
+      aria-label="Scroll to bottom"
+    >
+      <ChevronDown className="w-6 h-6" />
+    </button>
+  );
+};

--- a/src/components/LlmChat/context/types.ts
+++ b/src/components/LlmChat/context/types.ts
@@ -1,7 +1,7 @@
 import { Message } from '../types';
 import { McpServer } from '../types/mcp';
-import { Tool as ATool } from '@anthropic-ai/sdk/resources/messages/messages';
 import { ProviderConfig, LegacyProviderType, LegacyProviderSettings } from '../types/provider';
+import { Tool } from '../types/toolTypes';
 
 // Keep for backwards compatibility
 export type ProviderType = LegacyProviderType;
@@ -67,8 +67,5 @@ export interface ProjectState {
   setActiveConversation: (conversationId: string | null) => void;
 }
 
-export interface Tool {
-  name: string,
-  inputSchema: ATool.InputSchema,
-  description?: string,
-};
+// Re-export Tool for convenience
+export type { Tool };

--- a/src/components/LlmChat/hooks/useMessageSender.ts
+++ b/src/components/LlmChat/hooks/useMessageSender.ts
@@ -1,0 +1,629 @@
+import { useState, useRef, useCallback } from 'react';
+import { Anthropic } from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+import type { Tool as AnthropicToolType, CacheControlEphemeral, TextBlockParam } from '@anthropic-ai/sdk/resources/messages/messages';
+import { Message, MessageContent } from '../types';
+import { useStore } from '@/stores/rootStore';
+import { wakeLock } from '@/lib/wakeLock';
+import { GenericMessage, toAnthropicFormat, toOpenAIFormat, sanitizeFunctionName } from '../types/genericMessage';
+
+const DEFAULT_MODEL = 'claude-3-5-sonnet-20241022';
+
+export const useMessageSender = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const shouldCancelRef = useRef<boolean>(false);
+  const streamRef = useRef<{ abort: () => void } | null>(null);
+
+  const {
+    projects,
+    activeProjectId,
+    activeConversationId,
+    updateProjectSettings,
+    renameConversation,
+    servers,
+    executeTool
+  } = useStore();
+
+  const activeProject = projects.find(p => p.id === activeProjectId);
+
+  const getUniqueTools = useCallback((should_cache: boolean) => {
+    if (!activeProject?.settings.mcpServerIds?.length) {
+      return [];
+    }
+
+    const toolMap = new Map<string, AnthropicToolType>();
+
+    servers
+      .filter(server =>
+        activeProject.settings.mcpServerIds.includes(server.id)
+      )
+      .flatMap(s => s.tools || [])
+      .forEach((tool: AnthropicToolType) => {
+        if (!toolMap.has(tool.name)) {
+          toolMap.set(tool.name, {
+            name: tool.name,
+            description: tool.description || `Tool ${tool.name}`,
+            input_schema: tool.input_schema,
+          });
+        }
+      });
+
+    const tools = Array.from(toolMap.values());
+    return !should_cache ? tools : tools.map((t, index, array) => index != array.length - 1 ? t : { ...t, cache_control: { type: 'ephemeral' } as CacheControlEphemeral });
+  }, [activeProject?.settings.mcpServerIds, servers]);
+
+  const updateConversationMessages = useCallback((projectId: string, conversationId: string, newMessages: Message[]) => {
+    const currentConversation = activeProject?.conversations.find(c => c.id === conversationId);
+    if (!currentConversation) return;
+
+    updateProjectSettings(projectId, {
+      conversations: activeProject!.conversations.map(conv =>
+        conv.id === conversationId
+          ? {
+            ...currentConversation,
+            messages: newMessages,
+            lastUpdated: new Date()
+          }
+          : conv
+      )
+    });
+  }, [activeProject, updateProjectSettings]);
+
+  const cancelCurrentCall = useCallback(() => {
+    shouldCancelRef.current = true;
+    if (streamRef.current) {
+      streamRef.current.abort();
+    }
+    setIsLoading(false);
+    setError('Operation cancelled');
+  }, []);
+
+  const handleSendMessage = async (
+    inputMessage: string,
+    currentFileContent: MessageContent[]
+  ): Promise<void> => {
+    shouldCancelRef.current = false;
+    if ((!inputMessage.trim() && currentFileContent.length === 0) || !activeProject || !activeConversationId) {
+      return;
+    }
+
+    setError(null);
+    setIsLoading(true);
+
+    const currentApiKey = activeProject.settings.provider === 'openrouter'
+      ? activeProject.settings.openRouterApiKey
+      : (activeProject.settings.anthropicApiKey || activeProject.settings.apiKey);
+
+    if (!currentApiKey?.trim()) {
+      setError(`API key not found. Please set your ${activeProject.settings.provider === 'openrouter' ? 'OpenRouter' : 'Anthropic'} API key in the Settings panel.`);
+      setIsLoading(false);
+      return;
+    }
+
+    await wakeLock.acquire();
+    try {
+      const userMessageContent: MessageContent[] = currentFileContent.map(c =>
+        c.type === 'image' ? { ...c, fileName: undefined } : { ...c, fileName: undefined }
+      );
+
+      if (inputMessage.trim()) {
+        userMessageContent.push({
+          type: 'text' as const,
+          text: inputMessage,
+        });
+      }
+
+      const activeConversation = activeProject.conversations.find(c => c.id === activeConversationId);
+      const userMessage: Message = {
+        role: 'user',
+        content: userMessageContent,
+        timestamp: new Date()
+      };
+
+      const currentMessages = [...(activeConversation?.messages || []), userMessage];
+      updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
+      const anthropic = new Anthropic({
+        apiKey: activeProject.settings.anthropicApiKey || activeProject.settings.apiKey || '',
+        dangerouslyAllowBrowser: true,
+        maxRetries: 12,
+      });
+
+      const toolsCached = getUniqueTools(true);
+      const tools = getUniqueTools(false);
+
+      const systemPrompt = activeProject.settings.systemPrompt?.trim();
+      const systemPromptContent = systemPrompt ? [
+        {
+          type: "text",
+          text: systemPrompt,
+        },
+      ] as TextBlockParam[] : undefined;
+
+      console.log("Using provider:", activeProject.settings.provider);
+
+      const streamWithRetry = async (params: Parameters<typeof anthropic.messages.create>[0]) => {
+        let lastError: unknown;
+        for (let attempt = 0; attempt < 12; attempt++) {
+          try {
+            const stream = await anthropic.messages.stream(params);
+            return stream;
+          } catch (error) {
+            lastError = error;
+            if (typeof error === 'object' && error !== null) {
+              const errorObj = error as { error?: { type?: string }; status?: number };
+              const isOverloaded = errorObj.error?.type === 'overloaded_error' || errorObj.status === 429;
+              if (isOverloaded && attempt < 11) {
+                await new Promise(resolve => setTimeout(resolve, 5000));
+                continue;
+              }
+            }
+            throw error;
+          }
+        }
+        throw lastError;
+      };
+
+      while (true) {
+        if (shouldCancelRef.current) break;
+
+        const apiMessagesToSend = currentMessages.filter((message, index, array) => {
+          if (typeof message.content === 'string') return true;
+
+          const messageContent = message.content as MessageContent[];
+          const hasToolUse = messageContent.some(c => c.type === 'tool_use');
+          if (!hasToolUse) return true;
+
+          const nextMessage = array[index + 1];
+          if (!nextMessage) return false;
+          if (typeof nextMessage.content === 'string') return false;
+
+          const nextMessageContent = nextMessage.content as MessageContent[];
+
+          return messageContent.every(content => {
+            if (content.type !== 'tool_use') return true;
+            if (!('id' in content)) return true;
+            const toolId = content.id;
+            return nextMessageContent.some(
+              nextContent =>
+                nextContent.type === 'tool_result' &&
+                'tool_use_id' in nextContent &&
+                nextContent.tool_use_id === toolId
+            );
+          });
+        })
+          .map((m, index, array) =>
+            activeProject.settings.provider !== 'anthropic' || index < array.length - 3 ?
+              {
+                role: m.role,
+                content: m.content,
+                toolInput: m.toolInput ? m.toolInput : undefined,
+              } :
+              {
+                role: m.role,
+                content: (typeof m.content === 'string' ?
+                  [{ type: 'text' as const, text: m.content, cache_control: { type: 'ephemeral' } as CacheControlEphemeral }]
+                  : m.content.map((c, index, array) =>
+                    index != array.length - 1 ? c :
+                      {
+                        ...c,
+                        cache_control: { type: 'ephemeral' } as CacheControlEphemeral,
+                      }
+                  )) as MessageContent[],
+                toolInput: m.toolInput ? m.toolInput : undefined,
+              }
+          );
+
+        const genericMessagesToSend: GenericMessage[] = apiMessagesToSend.map(msg => ({
+          role: msg.role,
+          content: msg.content,
+          name: msg.toolInput as string | undefined
+        }));
+
+        const currentStreamMessage = {
+          role: 'assistant' as const,
+          content: [] as MessageContent[],
+          timestamp: new Date(),
+        };
+
+        const textContent: MessageContent = {
+          type: 'text',
+          text: '',
+        };
+        currentStreamMessage.content.push(textContent);
+
+        if (activeProject.settings.provider === 'openai' || activeProject.settings.provider === 'openrouter') {
+          const baseURL = activeProject.settings.provider === 'openrouter' ? 'https://openrouter.ai/api/v1' : undefined;
+          const apiKey = activeProject.settings.provider === 'openrouter' ? activeProject.settings.openRouterApiKey : activeProject.settings.openaiApiKey;
+          const openai = new OpenAI({
+            baseURL,
+            apiKey,
+            dangerouslyAllowBrowser: true,
+          });
+
+          try {
+            const openAIApiMessages = toOpenAIFormat(genericMessagesToSend, tools);
+            const stream = await openai.chat.completions.create({
+              model: activeProject.settings.model || 'gpt-4',
+              messages: openAIApiMessages.messages,
+              tools: openAIApiMessages.tools,
+              stream: true,
+              max_tokens: 4096,
+            });
+
+            let functionCallBuffer: { name: string; arguments: string } | null = null;
+
+            for await (const chunk of stream) {
+              if (shouldCancelRef.current) break;
+
+              const content = chunk?.choices?.[0]?.delta?.content;
+              const functionCallDelta = chunk?.choices?.[0]?.delta?.tool_calls;
+
+              if (functionCallDelta) {
+                const delta = functionCallDelta[0];
+                if (!functionCallBuffer) {
+                  if (delta.function) {
+                    functionCallBuffer = {
+                      name: delta.function.name || '',
+                      arguments: delta.function.arguments || '',
+                    };
+                  }
+                } else if (delta.function) {
+                  const currentName: string = functionCallBuffer?.name || '';
+                  const currentArgs: string = functionCallBuffer?.arguments || '';
+                  functionCallBuffer = {
+                  name: currentName || delta.function.name || '',
+                    arguments: currentArgs + (delta.function.arguments || ''),
+                  };
+                }
+              }
+
+              if (content) {
+                textContent.text += content;
+                const updatedMessages = [...currentMessages, currentStreamMessage];
+                updateConversationMessages(activeProject.id, activeConversationId, updatedMessages);
+              }
+            }
+
+            if (functionCallBuffer) {
+              const functionName = functionCallBuffer.name;
+              const functionArgs = JSON.parse(functionCallBuffer.arguments || '{}');
+
+              const serverWithTool = servers.find(s =>
+                s.tools?.some(t => sanitizeFunctionName(t.name) === functionName)
+              );
+
+              const unsanitizedTool = serverWithTool?.tools?.find(t => sanitizeFunctionName(t.name) === functionName);
+
+              if (!serverWithTool || !unsanitizedTool) {
+                throw new Error(`No server found for tool ${functionName}`);
+              }
+
+              const toolUseContent: MessageContent = {
+                type: 'tool_use',
+                id: `tool_use_${Date.now()}`,
+                name: unsanitizedTool.name as string,
+                input: functionArgs,
+              };
+
+              if (currentStreamMessage.content.length == 1 && currentStreamMessage.content[0].type === 'text' && currentStreamMessage.content[0].text === '') {
+                currentStreamMessage.content = [toolUseContent];
+              } else {
+                currentStreamMessage.content.push(toolUseContent);
+              }
+              updateConversationMessages(activeProject.id, activeConversationId, [...currentMessages, currentStreamMessage]);
+
+              const currentConversation = activeProject?.conversations.find(c => c.id === activeConversationId);
+              if (currentConversation && currentMessages.length === 3 && currentConversation.name === '(New Chat)') {
+                const userFirstMessage = currentMessages[0].content;
+                const assistantFirstMessage = currentMessages[1].content;
+
+                const summaryResponse = await openai.chat.completions.create({
+                  model: activeProject.settings.model || 'gpt-4',
+                  messages: [{
+                    role: "user",
+                    content: `Generate a concise, specific title (3-4 words max) that accurately captures the main topic or purpose of this conversation. Use key technical terms when relevant. Avoid generic words like 'conversation', 'chat', or 'help'.
+
+User message: ${JSON.stringify(userFirstMessage)}
+Assistant response: ${Array.isArray(assistantFirstMessage)
+                        ? assistantFirstMessage.filter(c => c.type === 'text').map(c => c.type === 'text' ? c.text : '').join(' ')
+                        : assistantFirstMessage}
+
+Format: Only output the title, no quotes or explanation`
+                  }],
+                  max_tokens: 20,
+                });
+
+                if (summaryResponse.choices[0].message.content) {
+                  const suggestedTitle = summaryResponse.choices[0].message.content
+                    .replace(/["']/g, '')
+                    .replace(/title:?\s*/i, '')
+                    .trim();
+                  if (suggestedTitle) {
+                    renameConversation(activeProject.id, activeConversationId, suggestedTitle);
+                  }
+                }
+              }
+
+              try {
+                const result = await executeTool(
+                  serverWithTool.id,
+                  unsanitizedTool.name as string,
+                  functionArgs,
+                );
+
+                const toolResultMessage: Message = {
+                  role: 'user',
+                  content: [{
+                    type: 'tool_result',
+                    tool_use_id: toolUseContent.id,
+                    content: result,
+                  }],
+                  timestamp: new Date()
+                };
+
+                currentMessages.push(currentStreamMessage);
+                currentMessages.push(toolResultMessage);
+                updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
+              } catch (toolError) {
+                const errorMessage: Message = {
+                  role: 'user',
+                  content: [{
+                    type: 'tool_result',
+                    tool_use_id: toolUseContent.id,
+                    content: `Error: ${toolError instanceof Error ? toolError.message : 'Unknown error'}`,
+                    is_error: true,
+                  }],
+                  timestamp: new Date()
+                };
+                const updatedMessagesWithError = [...currentMessages, currentStreamMessage, errorMessage];
+                updateConversationMessages(activeProject.id, activeConversationId, updatedMessagesWithError);
+              }
+            } else {
+              currentMessages.push(currentStreamMessage);
+              updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
+              const currentConversation = activeProject?.conversations.find(c => c.id === activeConversationId);
+              if (currentConversation && currentMessages.length === 3 && currentConversation.name === '(New Chat)') {
+                const userFirstMessage = currentMessages[0].content;
+                const assistantFirstMessage = currentMessages[1].content;
+
+                const summaryResponse = await openai.chat.completions.create({
+                  model: activeProject.settings.model || 'gpt-4',
+                  messages: [{
+                    role: "user",
+                    content: `Generate a concise, specific title (3-4 words max) that accurately captures the main topic or purpose of this conversation. Use key technical terms when relevant. Avoid generic words like 'conversation', 'chat', or 'help'.
+
+User message: ${JSON.stringify(userFirstMessage)}
+Assistant response: ${Array.isArray(assistantFirstMessage)
+                        ? assistantFirstMessage.filter(c => c.type === 'text').map(c => c.type === 'text' ? c.text : '').join(' ')
+                        : assistantFirstMessage}
+
+Format: Only output the title, no quotes or explanation`
+                  }],
+                  max_tokens: 20,
+                });
+
+                if (summaryResponse.choices[0].message.content) {
+                  const suggestedTitle = summaryResponse.choices[0].message.content
+                    .replace(/["']/g, '')
+                    .replace(/title:?\s*/i, '')
+                    .trim();
+                  if (suggestedTitle) {
+                    renameConversation(activeProject.id, activeConversationId, suggestedTitle);
+                  }
+                }
+              }
+
+              break;
+            }
+
+          } catch (error) {
+            console.error("OpenAI API error:", error);
+            setError(`OpenAI API error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+          }
+
+        } else if (activeProject.settings.provider === 'anthropic') {
+          const anthropicApiMessages = toAnthropicFormat(
+            genericMessagesToSend,
+            systemPrompt,
+          );
+
+          const stream = await streamWithRetry({
+            model: activeProject.settings.model || DEFAULT_MODEL,
+            max_tokens: 8192,
+            messages: anthropicApiMessages.messages,
+            ...(anthropicApiMessages.system && { system: anthropicApiMessages.system }),
+            ...(systemPromptContent && systemPromptContent.length > 0 && {
+              system: systemPromptContent
+            }),
+            ...(tools.length > 0 && {
+              tools: toolsCached
+            })
+          });
+
+          stream.on('text', (text) => {
+            textContent.text += text;
+            const updatedMessages = [...currentMessages, currentStreamMessage];
+            updateConversationMessages(activeProject.id, activeConversationId, updatedMessages);
+          });
+
+          streamRef.current = stream;
+
+          if (shouldCancelRef.current) break;
+
+          const finalResponse = await stream.finalMessage();
+
+          const processedContent = finalResponse.content.map((content: MessageContent) => {
+            if (!content['type']) return content;
+            if (content.type !== 'text') return content;
+
+            const isWhitespace = content.text.trim().length === 0;
+
+            if (isWhitespace && finalResponse.content.length === 1) {
+              return {
+                ...content,
+                text: 'empty',
+              } as MessageContent;
+            }
+            return content;
+          })
+            .filter((content: MessageContent) => {
+              if (!content['type']) return true;
+              if (content.type !== 'text') return true;
+
+              const isWhitespace = content.text.trim().length === 0;
+
+              if (isWhitespace && finalResponse.content.length === 1) {
+                console.log(`got unexpected whitespace case from assistant: ${JSON.stringify(finalResponse)}`);
+                content.text = 'empty';
+                return true;
+              }
+
+              return !isWhitespace;
+            });
+
+          const processedResponse = {
+            ...finalResponse,
+            content: processedContent
+          };
+
+          currentMessages.push(processedResponse);
+          updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
+          const currentConversation = activeProject?.conversations.find(c => c.id === activeConversationId);
+          if (currentConversation && currentMessages.length === 2 && currentConversation.name === '(New Chat)') {
+            const userFirstMessage = currentMessages[0].content;
+            const assistantFirstMessage = currentMessages[1].content;
+
+            const summaryResponse = await anthropic.messages.create({
+              model: activeProject.settings.model || DEFAULT_MODEL,
+              max_tokens: 20,
+              messages: [{
+                role: "user",
+                content: `Generate a concise, specific title (3-4 words max) that accurately captures the main topic or purpose of this conversation. Use key technical terms when relevant. Avoid generic words like 'conversation', 'chat', or 'help'.
+
+User message: ${JSON.stringify(userFirstMessage)}
+Assistant response: ${Array.isArray(assistantFirstMessage)
+                    ? assistantFirstMessage.filter(c => c.type === 'text').map(c => c.type === 'text' ? c.text : '').join(' ')
+                    : assistantFirstMessage}
+
+Format: Only output the title, no quotes or explanation`
+              }]
+            });
+
+            if (summaryResponse.content[0].type === 'text') {
+              const suggestedTitle = summaryResponse.content[0].text
+                .replace(/["']/g, '')
+                .replace(/title:?\s*/i, '')
+                .trim();
+              if (suggestedTitle) {
+                renameConversation(activeProject.id, activeConversationId, suggestedTitle);
+              }
+            }
+          }
+
+          const toolUseContent = finalResponse.content.find((c: MessageContent) => c.type === 'tool_use');
+          if (toolUseContent && toolUseContent.type === 'tool_use') {
+            try {
+              if (shouldCancelRef.current) break;
+
+              const serverWithTool = servers.find(s =>
+                s.tools?.some(t => t.name === toolUseContent.name)
+              );
+
+              if (!serverWithTool) {
+                throw new Error(`No server found for tool ${toolUseContent.name}`);
+              }
+
+              const result = await executeTool(
+                serverWithTool.id,
+                toolUseContent.name,
+                toolUseContent.input as Record<string, unknown>,
+              );
+
+              if (shouldCancelRef.current) break;
+
+              const toolResultMessage: Message = {
+                role: 'user',
+                content: [{
+                  type: 'tool_result',
+                  tool_use_id: toolUseContent.id,
+                  content: typeof result === 'string' ? result : JSON.stringify(result),
+                }],
+                timestamp: new Date()
+              };
+
+              currentMessages.push(toolResultMessage);
+              updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
+              if (!shouldCancelRef.current) continue;
+              break;
+            } catch (error) {
+              const errorMessage: Message = {
+                role: 'user',
+                content: [{
+                  type: 'tool_result',
+                  tool_use_id: toolUseContent.id,
+                  content: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                  is_error: true,
+                }],
+                timestamp: new Date()
+              };
+
+              currentMessages.push(errorMessage);
+              updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+            }
+          }
+
+          if (!toolUseContent) break;
+
+        } else {
+          setIsLoading(false);
+          wakeLock.release();
+          return;
+        }
+
+        if (shouldCancelRef.current) break;
+      }
+
+    } catch (error) {
+      console.error('Failed to send message:', error);
+      if (error instanceof Error && error.message === 'Request was aborted.') {
+        console.log('Request was cancelled by user');
+      } else if (typeof error === 'object' && error !== null) {
+        const errorObj = error as { error?: { type?: string }; status?: number };
+        const isOverloaded = errorObj.error?.type === 'overloaded_error' || errorObj.status === 429;
+
+        if (isOverloaded) {
+          console.error('Server overloaded, all retries failed:', error);
+          if (!shouldCancelRef.current) {
+            setError('Server is currently overloaded. Message sending failed after multiple retries. Please try again later.');
+          }
+        } else {
+          if (!shouldCancelRef.current) {
+            setError(error instanceof Error ? error.message : 'An error occurred');
+          }
+        }
+      } else {
+        if (!shouldCancelRef.current) {
+          setError(error instanceof Error ? error.message : 'An error occurred');
+        }
+      }
+    } finally {
+      shouldCancelRef.current = false;
+      setIsLoading(false);
+      streamRef.current = null;
+      await wakeLock.release();
+    }
+  };
+
+  return {
+    isLoading,
+    error,
+    handleSendMessage,
+    cancelCurrentCall
+  };
+};

--- a/src/components/LlmChat/hooks/useScrollControl.ts
+++ b/src/components/LlmChat/hooks/useScrollControl.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+import { throttle } from 'lodash';
+
+interface UseScrollControlProps {
+  messages: {
+    role: string;
+    content: string | Array<{
+      type: string;
+      [key: string]: unknown;
+    }>;
+  }[];
+}
+
+export const useScrollControl = ({ messages }: UseScrollControlProps) => {
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  useEffect(() => {
+    const makeHandleScroll = async () => {
+      while (!chatContainerRef.current) {
+        await new Promise(resolve => setTimeout(resolve, 250));
+      }
+
+      const container = chatContainerRef.current;
+
+      // Initial scroll to bottom
+      if (container.scrollTop === 0) {
+        container.scrollTop = container.scrollHeight;
+      }
+
+      // Handle scroll events
+      const handleScroll = throttle(() => {
+        const { scrollTop, scrollHeight, clientHeight } = container;
+        const bottom = container.scrollHeight < container.clientHeight || 
+          Math.abs(scrollHeight - clientHeight - scrollTop) < 50;
+        setIsAtBottom(bottom);
+      }, 100);
+
+      // Check initial scroll position
+      handleScroll();
+
+      container.addEventListener('scroll', handleScroll);
+      return () => container.removeEventListener('scroll', handleScroll);
+    };
+
+    makeHandleScroll();
+  }, []);
+
+  // Auto-scroll when messages update
+  useEffect(() => {
+    if (!chatContainerRef.current || !messages.length) {
+      return;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    const isInitialMessage = messages.length <= 1;
+
+    if ((lastMessage.role === 'assistant' || lastMessage.role === 'user') && 
+        (isAtBottom || isInitialMessage)) {
+      requestAnimationFrame(() => {
+        const container = chatContainerRef.current;
+        if (container) {
+          container.scrollTop = container.scrollHeight;
+        }
+      });
+    }
+  }, [messages, isAtBottom]);
+
+  const scrollToBottom = () => {
+    const container = chatContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
+  };
+
+  return {
+    chatContainerRef,
+    isAtBottom,
+    scrollToBottom
+  };
+};

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -24,6 +24,12 @@ export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: str
 export function toOpenAIFormat(messages: GenericMessage[]): any {
   const openaiMessages = [];
   for (const msg of messages) {
+    if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_use')) {
+      continue;
+    }
+    if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_result')) {
+      continue;
+    }
     openaiMessages.push({
       role: msg.role, // OpenAI uses the same role names: "system", "user", "assistant"
       content: msg.content, // Assuming content is directly compatible or will be stringified

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -1,7 +1,38 @@
+import { MessageContent } from '../types';
+
 export interface GenericMessage {
   role: 'user' | 'assistant' | 'system';
   content: any; // Keep it flexible for now, can be string or MessageContent[]
   name?: string; // Ensure name is string or undefined to match with toolInput type
+}
+
+// Define the OpenAI function format - simplified
+interface OpenAIFunction {
+  type: 'function';
+  name: string; // Name directly at the top level
+  description: string; // Description directly at the top level
+  parameters: any; // Parameters directly at the top level
+}
+
+// Function to sanitize function names for OpenAI compatibility
+function sanitizeFunctionName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase(); // Replace non-alphanumeric and non-underscore with underscore, and lowercase
+}
+
+// Function to convert Anthropic tool to OpenAI function format - simplified structure with description truncation
+function anthropicToolToOpenAIFunction(anthropicTool: any): OpenAIFunction {
+  let description = anthropicTool.description;
+  if (description && description.length > 1024) {
+    console.warn(`Tool description for '${anthropicTool.name}' is too long (${description.length} characters). Truncating to 1024 characters.`);
+    description = description.substring(0, 1021) + '...'; // Truncate and add ellipsis
+  }
+
+  return {
+    type: 'function',
+    name: sanitizeFunctionName(anthropicTool.name), // Name directly here
+    description: description, // Use potentially truncated description
+    parameters: anthropicTool.input_schema, // Parameters directly here
+  };
 }
 
 export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: string): any {
@@ -21,39 +52,46 @@ export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: str
   return anthropicPayload;
 }
 
-export function toOpenAIFormat(messages: GenericMessage[]): any {
+export function toOpenAIFormat(messages: GenericMessage[], tools?: any[]): any {
   const openaiMessages = [];
   for (const msg of messages) {
     if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_use')) {
-      continue;
+      continue; // Skip tool_use messages for OpenAI format - they are handled differently
     }
     if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_result')) {
-      continue;
+      continue; // Skip tool_result messages for OpenAI format - they are handled differently
     }
     openaiMessages.push({
-      role: msg.role, // OpenAI uses the same role names: "system", "user", "assistant"
-      content: msg.content, // Assuming content is directly compatible or will be stringified
-      // name: msg.name, // OpenAI function calls might use 'name', but we're not handling functions yet
+      role: msg.role,
+      content: msg.content,
+      name: msg.name, // Include name if available, might be needed for function calls
     });
   }
-  return { messages: openaiMessages }; // OpenAI expects messages to be within a 'messages' array in the request body
+
+  const openaiPayload: any = { messages: openaiMessages };
+
+  // Convert and add tools to the payload if provided
+  if (tools && tools.length > 0) {
+    openaiPayload.functions = tools.map(anthropicToolToOpenAIFunction);
+  }
+
+  return openaiPayload;
 }
 
 import { Message } from '../types'; // Assuming Message type is in '../types'
 
 export function messageToGenericMessage(message: Message): GenericMessage {
   return {
-    role: message.role as 'user' | 'assistant' | 'system', // Ensure correct role type
-    content: message.content, // Directly copy content - it can be string or MessageContent[]
-    name: message.toolInput as string | undefined, // Map toolInput to name if it's relevant for generic format, ensure type matches GenericMessage
+    role: message.role as 'user' | 'assistant' | 'system',
+    content: message.content,
+    name: message.toolInput as string | undefined,
   };
 }
 
 export function genericMessageToMessage(genericMessage: GenericMessage): Message {
   return {
-    role: genericMessage.role as 'user' | 'assistant', // Correct role type for Message, system is not allowed here
+    role: genericMessage.role as 'user' | 'assistant',
     content: genericMessage.content,
-    timestamp: new Date(), // You might want to preserve the original timestamp if available in GenericMessage later
-    // ... any other properties in your Message type that need to be mapped or defaulted
+    timestamp: new Date(),
   };
 } 

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -1,0 +1,30 @@
+export interface GenericMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: any; // Keep it flexible for now, can be string or MessageContent[]
+  name?: string;
+}
+
+export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: string): any {
+  const anthropicMessages = [];
+  for (const msg of messages) {
+    if (msg.role === 'system') {
+      systemPrompt = msg.content; // Assuming only one system message, or taking the last one
+    } else {
+      anthropicMessages.push({ role: msg.role, content: msg.content }); // Anthropic also uses 'role' and 'content'
+    }
+  }
+
+  const anthropicPayload: any = { messages: anthropicMessages };
+  if (systemPrompt) {
+    anthropicPayload.system = systemPrompt;
+  }
+  return anthropicPayload;
+}
+
+export function toOpenAIFormat(messages: GenericMessage[]): any {
+  const openaiMessages = [];
+  for (const msg of messages) {
+    openaiMessages.push({ role: msg.role, content: msg.content, name: msg.name });
+  }
+  return openaiMessages;
+} 

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -1,7 +1,7 @@
 export interface GenericMessage {
   role: 'user' | 'assistant' | 'system';
   content: any; // Keep it flexible for now, can be string or MessageContent[]
-  name?: string;
+  name?: string; // Ensure name is string or undefined to match with toolInput type
 }
 
 export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: string): any {
@@ -45,13 +45,13 @@ export function messageToGenericMessage(message: Message): GenericMessage {
   return {
     role: message.role as 'user' | 'assistant' | 'system', // Ensure correct role type
     content: message.content, // Directly copy content - it can be string or MessageContent[]
-    name: message.toolInput, // Map toolInput to name if it's relevant for generic format
+    name: message.toolInput as string | undefined, // Map toolInput to name if it's relevant for generic format, ensure type matches GenericMessage
   };
 }
 
 export function genericMessageToMessage(genericMessage: GenericMessage): Message {
   return {
-    role: genericMessage.role,
+    role: genericMessage.role as 'user' | 'assistant', // Correct role type for Message, system is not allowed here
     content: genericMessage.content,
     timestamp: new Date(), // You might want to preserve the original timestamp if available in GenericMessage later
     // ... any other properties in your Message type that need to be mapped or defaulted

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -1,99 +1,154 @@
 import { MessageContent } from '../types';
+import type {
+  ChatCompletionMessageParam as OpenAIMessageParam,
+  ChatCompletionTool,
+  ChatCompletionToolMessageParam,
+  ChatCompletionUserMessageParam,
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionSystemMessageParam
+} from 'openai/resources/chat/completions';
+import type { Tool as AnthropicToolType } from '@anthropic-ai/sdk/resources/messages/messages';
+import { Tool } from './toolTypes';
 
+// Define OpenAI function call type
+export interface FunctionCall {
+  name?: string;
+  arguments?: string;
+}
+
+// Generic message interface with all supported roles
 export interface GenericMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: any; // Keep it flexible for now, can be string or MessageContent[]
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | MessageContent[]; // Using specific type instead of any
   name?: string; // Ensure name is string or undefined to match with toolInput type
 }
 
-// Define the OpenAI function format
-interface OpenAIFunctionParameter {
-  type: string;
-  properties: Record<string, {
-    type: string;
-    description?: string;
-    enum?: string[];
-  }>;
-  required?: string[];
-  additionalProperties?: boolean;
-}
-
-interface OpenAIFunction {
-  type: 'function';
-  function: {
-    name: string;
-    description: string;
-    parameters: OpenAIFunctionParameter;
-  };
-}
-
-interface OpenAITool {
-  type: 'function';
-  function: OpenAIFunction['function'];
-}
-
 // Function to sanitize function names for OpenAI compatibility
-function sanitizeFunctionName(name: string): string {
+export function sanitizeFunctionName(name: string): string {
   return name.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase(); // Replace non-alphanumeric and non-underscore with underscore, and lowercase
 }
 
-// Function to convert Anthropic tool to OpenAI function format
-function anthropicToolToOpenAIFunction(anthropicTool: any): OpenAITool {
-  let description = anthropicTool.description;
-  if (description && description.length > 1024) {
-    console.warn(`Tool description for '${anthropicTool.name}' is too long (${description.length} characters). Truncating to 1024 characters.`);
+function anthropicToolToOpenAIFunction(tool: Tool | AnthropicToolType): ChatCompletionTool {
+  let description = tool.description || '';
+  if (description.length > 1024) {
+    console.warn(`Tool description for '${tool.name}' is too long (${description.length} characters). Truncating to 1024 characters.`);
     description = description.substring(0, 1021) + '...';
   }
+
+  const properties: Record<string, { type: string; description?: string; enum?: string[] }> =
+    tool.input_schema?.properties ?? Object.create(null);
+
+  const required = (tool.input_schema?.required ?? []) as string[];
 
   return {
     type: 'function',
     function: {
-      name: sanitizeFunctionName(anthropicTool.name),
+      name: sanitizeFunctionName(tool.name),
       description: description,
       parameters: {
         type: 'object',
-        properties: anthropicTool.input_schema.properties || {},
-        required: anthropicTool.input_schema.required || [],
+        properties,
+        required,
         additionalProperties: false
       }
     }
   };
 }
 
-export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: string): any {
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | MessageContent[];
+}
+
+interface AnthropicPayload {
+  messages: AnthropicMessage[];
+  system?: string;
+}
+
+export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: string): AnthropicPayload {
   const anthropicMessages = [];
   for (const msg of messages) {
     if (msg.role === 'system') {
-      systemPrompt = msg.content; // Assuming only one system message, or taking the last one
+      if (typeof msg.content === 'string') {
+        systemPrompt = msg.content; // Only use string content for system prompt
+      } else if (Array.isArray(msg.content)) {
+        const textContent = msg.content.find(c => c.type === 'text');
+        if (textContent && 'text' in textContent) {
+          systemPrompt = textContent.text;
+        }
+      }
     } else {
-      anthropicMessages.push({ role: msg.role, content: msg.content }); // Anthropic also uses 'role' and 'content'
+      anthropicMessages.push({
+        role: msg.role === 'tool' ? 'user' : msg.role, // Convert 'tool' to 'user' for Anthropic
+        content: msg.content, // Type assertion since we know these types are compatible
+      });
     }
   }
 
-  const anthropicPayload: any = { messages: anthropicMessages };
+  const anthropicPayload: AnthropicPayload = { messages: anthropicMessages };
   if (systemPrompt) {
     anthropicPayload.system = systemPrompt;
   }
   return anthropicPayload;
 }
 
-export function toOpenAIFormat(messages: GenericMessage[], tools?: any[]): any {
-  const openaiMessages = [];
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+interface OpenAIPayload {
+  messages: Array<ChatCompletionMessageParam>;
+  tools?: ChatCompletionTool[];
+  tool_choice?: string;
+  function_calling?: {
+    allow_nested_function_calls: boolean;
+    allow_multiple_function_calls: boolean;
+  };
+}
+
+export function toOpenAIFormat(messages: GenericMessage[], tools?: Array<Tool | AnthropicToolType>): OpenAIPayload {
+  const openaiMessages: OpenAIMessageParam[] = [];
   for (const msg of messages) {
-    if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_use')) {
-      continue; // Skip tool_use messages for OpenAI format - they are handled differently
+    if (Array.isArray(msg.content)) {
+      const toolUseContent = msg.content.find(content => content.type === 'tool_use');
+      const toolResultContent = msg.content.find(content => content.type === 'tool_result');
+      const textContent = msg.content.find(content => content.type === 'text');
+
+      if (toolUseContent) {
+        openaiMessages.push({
+          role: 'assistant',
+          content: textContent?.text || '',
+          tool_calls: [{
+            id: toolUseContent.id,
+            type: 'function' as const,
+            function: {
+              name: toolUseContent.name,
+              arguments: JSON.stringify(toolUseContent.input),
+            },
+          }],
+          name: msg.name,
+        });
+      } else if (toolResultContent) {
+        openaiMessages.push({
+          role: 'tool',
+          tool_call_id: toolResultContent.tool_use_id,
+          content: toolResultContent.content,
+        } as ChatCompletionToolMessageParam);
+      } else {
+        openaiMessages.push({
+          role: msg.role as 'user' | 'assistant' | 'system',
+          content: textContent?.text || '',
+          name: msg.name,
+        } as ChatCompletionUserMessageParam | ChatCompletionAssistantMessageParam | ChatCompletionSystemMessageParam);
+      }
+    } else {
+      openaiMessages.push({
+        role: msg.role as 'user' | 'assistant' | 'system',
+        content: msg.content as string,
+        name: msg.name,
+      } as ChatCompletionUserMessageParam | ChatCompletionAssistantMessageParam | ChatCompletionSystemMessageParam);
     }
-    if (Array.isArray(msg.content) && msg.content.some(content => content.type === 'tool_result')) {
-      continue; // Skip tool_result messages for OpenAI format - they are handled differently
-    }
-    openaiMessages.push({
-      role: msg.role,
-      content: msg.content,
-      name: msg.name, // Include name if available, might be needed for function calls
-    });
   }
 
-  const openaiPayload: any = { messages: openaiMessages };
+  const openaiPayload: OpenAIPayload = { messages: openaiMessages };
 
   // Convert and add tools to the payload if provided
   if (tools && tools.length > 0) {
@@ -126,4 +181,4 @@ export function genericMessageToMessage(genericMessage: GenericMessage): Message
     content: genericMessage.content,
     timestamp: new Date(),
   };
-} 
+}

--- a/src/components/LlmChat/types/genericMessage.ts
+++ b/src/components/LlmChat/types/genericMessage.ts
@@ -24,7 +24,30 @@ export function toAnthropicFormat(messages: GenericMessage[], systemPrompt?: str
 export function toOpenAIFormat(messages: GenericMessage[]): any {
   const openaiMessages = [];
   for (const msg of messages) {
-    openaiMessages.push({ role: msg.role, content: msg.content, name: msg.name });
+    openaiMessages.push({
+      role: msg.role, // OpenAI uses the same role names: "system", "user", "assistant"
+      content: msg.content, // Assuming content is directly compatible or will be stringified
+      // name: msg.name, // OpenAI function calls might use 'name', but we're not handling functions yet
+    });
   }
-  return openaiMessages;
+  return { messages: openaiMessages }; // OpenAI expects messages to be within a 'messages' array in the request body
+}
+
+import { Message } from '../types'; // Assuming Message type is in '../types'
+
+export function messageToGenericMessage(message: Message): GenericMessage {
+  return {
+    role: message.role as 'user' | 'assistant' | 'system', // Ensure correct role type
+    content: message.content, // Directly copy content - it can be string or MessageContent[]
+    name: message.toolInput, // Map toolInput to name if it's relevant for generic format
+  };
+}
+
+export function genericMessageToMessage(genericMessage: GenericMessage): Message {
+  return {
+    role: genericMessage.role,
+    content: genericMessage.content,
+    timestamp: new Date(), // You might want to preserve the original timestamp if available in GenericMessage later
+    // ... any other properties in your Message type that need to be mapped or defaulted
+  };
 } 

--- a/src/components/LlmChat/types/provider.ts
+++ b/src/components/LlmChat/types/provider.ts
@@ -32,7 +32,7 @@ export function convertLegacyToProviderConfig(
       type: 'openrouter',
       settings: {
         apiKey: settings.openRouterApiKey || '',
-        baseUrl: settings.openRouterBaseUrl || '',
+        baseUrl: settings.openRouterBaseUrl || 'https://openrouter.ai/api/v1',
       }
     };
   } else if (provider === 'openai') {

--- a/src/components/LlmChat/types/toolTypes.ts
+++ b/src/components/LlmChat/types/toolTypes.ts
@@ -1,0 +1,27 @@
+export interface Tool {
+  name: string;
+  description: string;
+  input_schema: {
+    type?: 'object';
+    properties?: Record<string, {
+      type: string;
+      description?: string;
+      enum?: string[];
+    }>;
+    required?: string[];
+  };
+}
+
+export interface WsTool {
+  name: string;
+  description: string;
+  inputSchema: {
+    type?: 'object';
+    properties?: Record<string, {
+      type: string;
+      description?: string;
+      enum?: string[];
+    }>;
+    required?: string[];
+  };
+}

--- a/src/components/LlmChat/utils/ToolRegistry.ts
+++ b/src/components/LlmChat/utils/ToolRegistry.ts
@@ -1,0 +1,131 @@
+import { Tool } from '@anthropic-ai/sdk/resources/messages/messages';
+import { McpServer } from '../types/mcp';
+
+interface ToolReference {
+  serverId: string;  // Which server provides this tool
+  tool: Tool;        // The tool definition
+  provider: 'openai' | 'anthropic'; // Which provider format it's in
+}
+
+export class DynamicToolRegistry {
+  private toolMap: Map<string, ToolReference> = new Map();
+  private providerNameMap: Map<string, string> = new Map(); // OpenAI/Anthropic name to internal name
+  
+  // Update tools from a server
+  updateServerTools(server: McpServer) {
+    // Remove old tools from this server
+    this.removeServerTools(server.id);
+    
+    // Add new tools
+    server.tools?.forEach(tool => {
+      this.registerTool(server.id, tool);
+    });
+  }
+
+  // Remove all tools from a server (used when server disconnects)
+  removeServerTools(serverId: string) {
+    // Find and remove all tools from this server
+    for (const [name, ref] of this.toolMap.entries()) {
+      if (ref.serverId === serverId) {
+        this.toolMap.delete(name);
+        // Also clean up provider name mappings
+        for (const [providerName, internalName] of this.providerNameMap.entries()) {
+          if (internalName === name) {
+            this.providerNameMap.delete(providerName);
+          }
+        }
+      }
+    }
+  }
+
+  // Register a single tool
+  private registerTool(serverId: string, tool: Tool) {
+    const internalName = tool.name;
+    
+    // Store tool with server reference
+    this.toolMap.set(internalName, {
+      serverId,
+      tool,
+      provider: 'anthropic' // Default to Anthropic format since that's what MCP uses
+    });
+
+    // Map provider-specific names
+    const openaiName = this.sanitizeToolName(tool.name, 'openai');
+    const anthropicName = this.sanitizeToolName(tool.name, 'anthropic');
+    
+    this.providerNameMap.set(openaiName, internalName);
+    this.providerNameMap.set(anthropicName, internalName);
+  }
+
+  // Get tools in provider-specific format
+  getToolsForProvider(provider: 'openai' | 'anthropic', shouldCache = false): Tool[] {
+    return Array.from(this.toolMap.values()).map(ref => {
+      const providerTool = this.convertToolForProvider(ref.tool, provider);
+      if (shouldCache) {
+        return {
+          ...providerTool,
+          cache_control: { type: 'ephemeral' }
+        };
+      }
+      return providerTool;
+    });
+  }
+
+  // Find server for a tool
+  getServerForTool(toolName: string): string | undefined {
+    const internalName = this.providerNameMap.get(toolName);
+    if (!internalName) return undefined;
+    
+    const ref = this.toolMap.get(internalName);
+    return ref?.serverId;
+  }
+
+  // Get original tool name from provider-specific name
+  getInternalName(providerToolName: string): string | undefined {
+    return this.providerNameMap.get(providerToolName);
+  }
+
+  // Convert tool format between providers
+  private convertToolForProvider(tool: Tool, provider: 'openai' | 'anthropic'): Tool {
+    if (provider === 'openai') {
+      return {
+        type: 'function',
+        function: {
+          name: this.sanitizeToolName(tool.name, 'openai'),
+          description: tool.description,
+          parameters: tool.input_schema || {
+            type: 'object',
+            properties: {},
+            required: []
+          }
+        }
+      };
+    }
+    
+    // Return in Anthropic format
+    return {
+      name: this.sanitizeToolName(tool.name, 'anthropic'),
+      description: tool.description,
+      input_schema: tool.input_schema || {
+        type: 'object',
+        properties: {},
+        required: []
+      }
+    };
+  }
+
+  private sanitizeToolName(name: string, provider: 'openai' | 'anthropic'): string {
+    const sanitized = name.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase();
+    return provider === 'openai' ? sanitized : sanitized;
+  }
+
+  // Get all registered tools for debugging/display
+  getAllTools(): Map<string, ToolReference> {
+    return new Map(this.toolMap);
+  }
+
+  // Check if a tool exists
+  hasTool(name: string): boolean {
+    return this.providerNameMap.has(name) || this.toolMap.has(name);
+  }
+}

--- a/src/components/LlmChat/utils/ToolRegistry.ts
+++ b/src/components/LlmChat/utils/ToolRegistry.ts
@@ -1,9 +1,13 @@
-import { Tool } from '@anthropic-ai/sdk/resources/messages/messages';
+import { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
+import { ChatCompletionTool } from 'openai/resources/chat/completions';
 import { McpServer } from '../types/mcp';
+
+// Union type for both provider's tool formats
+type Tool = AnthropicTool | ChatCompletionTool;
 
 interface ToolReference {
   serverId: string;  // Which server provides this tool
-  tool: Tool;        // The tool definition
+  tool: AnthropicTool;  // The tool definition (we store in Anthropic format internally)
   provider: 'openai' | 'anthropic'; // Which provider format it's in
 }
 
@@ -39,7 +43,7 @@ export class DynamicToolRegistry {
   }
 
   // Register a single tool
-  private registerTool(serverId: string, tool: Tool) {
+  private registerTool(serverId: string, tool: AnthropicTool) {
     const internalName = tool.name;
     
     // Store tool with server reference
@@ -86,7 +90,7 @@ export class DynamicToolRegistry {
   }
 
   // Convert tool format between providers
-  private convertToolForProvider(tool: Tool, provider: 'openai' | 'anthropic'): Tool {
+  private convertToolForProvider(tool: AnthropicTool, provider: 'openai' | 'anthropic'): Tool {
     if (provider === 'openai') {
       return {
         type: 'function',
@@ -99,7 +103,7 @@ export class DynamicToolRegistry {
             required: []
           }
         }
-      };
+      } as ChatCompletionTool;
     }
     
     // Return in Anthropic format
@@ -111,7 +115,7 @@ export class DynamicToolRegistry {
         properties: {},
         required: []
       }
-    };
+    } as AnthropicTool;
   }
 
   private sanitizeToolName(name: string, provider: 'openai' | 'anthropic'): string {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -325,10 +325,7 @@ const sanitizeProjectForStorage = (project: Project): Project => {
       ...project.settings,
       mcpServerIds: project.settings.mcpServerIds || [],
       // Ensure providerConfig exists by converting from legacy if needed
-      providerConfig: project.settings.providerConfig || convertLegacyToProviderConfig(
-        project.settings.provider,
-        project.settings
-      )
+      providerConfig: project.settings.providerConfig // No legacy conversion
     },
     conversations: project.conversations.map(conv => ({
       ...conv,

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { Project, ProjectSettings, ConversationBrief, ProjectState, McpState, McpServerConnection, Tool } from '../components/LlmChat/context/types';
 import { McpServer } from '../components/LlmChat/types/mcp';
 import { loadState, saveState, loadMcpServers, saveMcpServers } from '../lib/db';
+import { GenericMessage, messageToGenericMessage } from '../components/LlmChat/types/genericMessage';
 
 const generateId = () => Math.random().toString(36).substring(7);
 
@@ -489,12 +490,12 @@ export const useStore = create<RootState>((set, get) => {
               ...p,
               settings: updates.settings
                 ? {
-                    ...p.settings,
-                    ...updates.settings,
-                    mcpServerIds: updates.settings.mcpServerIds !== undefined
-                      ? updates.settings.mcpServerIds
-                      : p.settings.mcpServerIds
-                  }
+                  ...p.settings,
+                  ...updates.settings,
+                  mcpServerIds: updates.settings.mcpServerIds !== undefined
+                    ? updates.settings.mcpServerIds
+                    : p.settings.mcpServerIds
+                }
                 : p.settings,
               conversations: updatedConversations,
               updatedAt: new Date()

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
-import { Project, ProjectSettings, ConversationBrief, ProjectState, McpState, McpServerConnection, Tool } from '../components/LlmChat/context/types';
+import { Project, ProjectSettings, ConversationBrief, ProjectState, McpState, McpServerConnection } from '../components/LlmChat/context/types';
 import { McpServer } from '../components/LlmChat/types/mcp';
 import { loadState, saveState, loadMcpServers, saveMcpServers } from '../lib/db';
-import { GenericMessage, messageToGenericMessage } from '../components/LlmChat/types/genericMessage';
+import { WsTool } from '../components/LlmChat/types/toolTypes';
 
 const generateId = () => Math.random().toString(36).substring(7);
 
@@ -22,11 +22,10 @@ const DEFAULT_MODEL = 'claude-3-5-sonnet-20241022';
 
 const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {
   providerConfig: {
-    anthropic: { apiKey: '', model: DEFAULT_MODEL },
-    openai: { apiKey: '', model: 'gpt-4o' },
-    openrouter: { apiKey: '', model: '' },
-    groq: { apiKey: '', model: '' },
-    perplexity: { apiKey: '', model: '' },
+    type: 'anthropic',
+    settings: {
+      apiKey: '',
+    }
   },
   provider: 'anthropic',
   model: DEFAULT_MODEL,
@@ -200,7 +199,7 @@ export const useStore = create<RootState>((set, get) => {
                 console.log('Received unexpected WS-MCP message:', response.results);
                 return server;
               }
-              const tools = response.result.tools.map((tool: Tool) => ({
+              const tools = response.result.tools.map((tool: WsTool) => ({
                 ...tool,
                 input_schema: tool.inputSchema,
               }));

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -6,7 +6,7 @@ import { GenericMessage, messageToGenericMessage } from '../components/LlmChat/t
 
 const generateId = () => Math.random().toString(36).substring(7);
 
-const getDefaultModelForProvider = (provider?: string): string => {
+export const getDefaultModelForProvider = (provider?: string): string => {
   switch (provider) {
     case 'openai':
       return 'gpt-4o';

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -18,13 +18,21 @@ export const getDefaultModelForProvider = (provider?: string): string => {
   }
 };
 
+const DEFAULT_MODEL = 'claude-3-5-sonnet-20241022';
+
 const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {
-  apiKey: '',
-  groqApiKey: '',
-  model: getDefaultModelForProvider('anthropic'),
+  providerConfig: {
+    anthropic: { apiKey: '', model: DEFAULT_MODEL },
+    openai: { apiKey: '', model: 'gpt-4o' },
+    openrouter: { apiKey: '', model: '' },
+    groq: { apiKey: '', model: '' },
+    perplexity: { apiKey: '', model: '' },
+  },
+  provider: 'anthropic',
+  model: DEFAULT_MODEL,
   systemPrompt: '',
-  mcpServerIds: [],
   elideToolResults: false,
+  mcpServerIds: [],
 };
 
 interface RootState extends ProjectState, McpState {
@@ -270,7 +278,6 @@ export const useStore = create<RootState>((set, get) => {
 
         // Always try to load saved servers first
         const savedServers = await loadMcpServers();
-        console.log('Loading servers from IndexedDB:', JSON.stringify(savedServers));
 
         const connectedServers: McpServerConnection[] = [];
 


### PR DESCRIPTION
# Generic Messages & Tool Registry

This PR adds a dynamic tool registry for managing MCP tools and a new view to display available tools in a user-friendly way.

## Changes

### Generic Messages
Have a format for all providers

### Tool Registry
- Added `DynamicToolRegistry` class to manage tools from MCP servers
- Tools automatically update when servers connect/disconnect
- Handles provider-specific tool format conversions (Anthropic/OpenAI)
- Maps tool names between different providers

### Tools View
- Added new Tools tab in AdminView
- Shows available tools grouped by server
- Each server shows connection status and tools
- Tools are collapsible (collapsed by default) for better UX
- Shows tool descriptions and input schemas