### PR TITLE
Save/Load System Prompts

### DIFF
--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -347,45 +347,49 @@ export const AdminView = () => {
             {/* Save Prompt Dialog */}
             <Dialog open={showSavePromptDialog} onOpenChange={setShowSavePromptDialog}>
               <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Save System Prompt</DialogTitle>
-                </DialogHeader>
-                <div className="py-4">
-                  <label className="block text-sm font-medium mb-2">
-                    Name your prompt
-                  </label>
-                  <Input
-                    value={newPromptName}
-                    onChange={(e) => setNewPromptName(e.target.value)}
-                    placeholder="Enter a name for this prompt"
-                  />
-                </div>
-                <DialogFooter>
-                  <Button variant="outline" onClick={() => setShowSavePromptDialog(false)}>
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      if (newPromptName.trim()) {
-                        const newPrompt = {
-                          id: crypto.randomUUID(),
-                          name: newPromptName.trim(),
-                          content: activeProject.settings.systemPrompt,
-                          createdAt: new Date()
-                        };
-                        handleSettingsChange({
-                          savedPrompts: [
-                            ...(activeProject.settings.savedPrompts || []),
-                            newPrompt
-                          ]
-                        });
-                        setShowSavePromptDialog(false);
-                      }
-                    }}
-                  >
-                    Save
-                  </Button>
-                </DialogFooter>
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    if (newPromptName.trim()) {
+                      const newPrompt = {
+                        id: crypto.randomUUID(),
+                        name: newPromptName.trim(),
+                        content: activeProject.settings.systemPrompt,
+                        createdAt: new Date()
+                      };
+                      handleSettingsChange({
+                        savedPrompts: [
+                          ...(activeProject.settings.savedPrompts || []),
+                          newPrompt
+                        ]
+                      });
+                      setShowSavePromptDialog(false);
+                    }
+                  }}
+                >
+                  <DialogHeader>
+                    <DialogTitle>Save System Prompt</DialogTitle>
+                  </DialogHeader>
+                  <div className="py-4">
+                    <label className="block text-sm font-medium mb-2">
+                      Name your prompt
+                    </label>
+                    <Input
+                      value={newPromptName}
+                      onChange={(e) => setNewPromptName(e.target.value)}
+                      placeholder="Enter a name for this prompt"
+                      autoFocus // Automatically focus the input when dialog opens
+                    />
+                  </div>
+                  <DialogFooter>
+                    <Button type="button" variant="outline" onClick={() => setShowSavePromptDialog(false)}>
+                      Cancel
+                    </Button>
+                    <Button type="submit">
+                      Save
+                    </Button>
+                  </DialogFooter>
+                </form>
               </DialogContent>
             </Dialog>
 

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -5,7 +5,7 @@ import { DB_VERSION } from '@/lib/db';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { SaveIcon, ChevronDownIcon } from 'lucide-react';
+import { SaveIcon, ChevronDownIcon, Trash2Icon } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -291,11 +291,31 @@ export const AdminView = () => {
                         {activeProject.settings.savedPrompts.map((prompt) => (
                           <DropdownMenuItem
                             key={prompt.id}
-                            onClick={() => handleSettingsChange({
-                              systemPrompt: prompt.content
-                            })}
+                            className="flex justify-between items-center"
                           >
-                            {prompt.name}
+                            <div
+                              onClick={() => handleSettingsChange({
+                                systemPrompt: prompt.content
+                              })}
+                              className="flex-grow cursor-pointer"
+                            >
+                              {prompt.name}
+                            </div>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-4 w-4 ml-2 hover:text-destructive"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleSettingsChange({
+                                  savedPrompts: activeProject.settings.savedPrompts?.filter(
+                                    p => p.id !== prompt.id
+                                  ) || []
+                                });
+                              }}
+                            >
+                              <Trash2Icon className="h-3 w-3" />
+                            </Button>
                           </DropdownMenuItem>
                         ))}
                       </DropdownMenuContent>

--- a/src/components/LlmChat/AdminView/index.tsx
+++ b/src/components/LlmChat/AdminView/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import { DB_VERSION } from '@/lib/db';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -330,7 +331,7 @@ export const AdminView = () => {
       <Card className="mt-6">
         <CardContent className="p-6">
           <h3 className="text-lg font-medium mb-4">Advanced Settings</h3>
-          <div className="text-xs text-muted-foreground mb-4">Database Version: 5</div>
+          <div className="text-xs text-muted-foreground mb-4">Database Version: {DB_VERSION}</div>
           <Button
             variant="destructive"
             onClick={() => setShowResetConfirm(true)}

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -67,7 +67,7 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
     }
 
     return messages;
-  }, [activeConversation?.messages, activeProject?.settings.showAllMessages, numMessages]);
+  }, [activeConversation?.messages, activeProject?.settings.showAllMessages, activeProject?.settings.messageWindowSize, numMessages]);
 
   //const [inputMessage, setInputMessage] = useState('');
   //const [isLoading, setIsLoading] = useState(false);

--- a/src/components/LlmChat/components/ChatInput.tsx
+++ b/src/components/LlmChat/components/ChatInput.tsx
@@ -5,7 +5,6 @@ import { VoiceRecorder } from '../VoiceRecorder';
 import { Button } from '@/components/ui/button';
 import { Send, Square } from 'lucide-react';
 import { MessageContent } from '../types';
-import { Switch } from '@/components/ui/switch';
 
 interface ChatInputProps {
   value: string;

--- a/src/components/LlmChat/context/types.ts
+++ b/src/components/LlmChat/context/types.ts
@@ -3,6 +3,13 @@ import { McpServer } from '../types/mcp';
 import { ProviderConfig, LegacyProviderType, LegacyProviderSettings } from '../types/provider';
 import { Tool } from '../types/toolTypes';
 
+export interface SavedPrompt {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: Date;
+}
+
 // Keep for backwards compatibility
 export type ProviderType = LegacyProviderType;
 
@@ -12,6 +19,7 @@ export interface ProjectSettings extends LegacyProviderSettings {
   model: string;
   groqApiKey?: string;  // API key for GROQ services
   systemPrompt: string;
+  savedPrompts?: SavedPrompt[];  // Collection of saved system prompts
   mcpServerIds: string[];  // Store server IDs instead of full server objects
   elideToolResults: boolean;
   showAllMessages: boolean;  // Toggle for showing all messages vs truncated view

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,7 +5,7 @@ import { McpServer } from '../components/LlmChat/types/mcp';
 import { messageToGenericMessage } from '../components/LlmChat/types/genericMessage';
 
 const DB_NAME = 'kibitz_db';
-const DB_VERSION = 6;
+export const DB_VERSION = 6;
 
 interface DbState {
   projects: Project[];

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,7 +5,7 @@ import { McpServer } from '../components/LlmChat/types/mcp';
 import { messageToGenericMessage } from '../components/LlmChat/types/genericMessage';
 
 const DB_NAME = 'kibitz_db';
-export const DB_VERSION = 6;
+export const DB_VERSION = 7;
 
 interface DbState {
   projects: Project[];
@@ -242,6 +242,40 @@ const initDb = async (): Promise<KibitzDb> => {
         // Add error handling for the cursor operation
         projectStore.openCursor().onerror = (error) => {
           console.error('Error during v6 migration:', error);
+        };
+      } else if (event.oldVersion < 7) {
+        // Add savedPrompts array to existing projects
+        const transaction = (event.target as IDBOpenDBRequest).transaction;
+        if (!transaction) {
+          console.error('No transaction available during upgrade');
+          return;
+        }
+        const projectStore = transaction.objectStore('projects');
+
+        // Migrate existing projects
+        projectStore.openCursor().onsuccess = (e) => {
+          const cursor = (e.target as IDBRequest<IDBCursorWithValue>).result;
+          if (cursor) {
+            const project = cursor.value;
+
+            try {
+              // Ensure settings exists and add empty savedPrompts array if not present
+              if (project.settings) {
+                if (!project.settings.savedPrompts) {
+                  project.settings.savedPrompts = [];
+                }
+                cursor.update(project);
+              }
+            } catch (error) {
+              console.error('Error updating project during v7 migration:', error);
+            }
+            cursor.continue();
+          }
+        };
+
+        // Add error handling for the cursor operation
+        projectStore.openCursor().onerror = (error) => {
+          console.error('Error during v7 migration:', error);
         };
       }
     };


### PR DESCRIPTION
# System Prompts Management

Adds ability to save and load system prompts in Settings, including:

- Save current system prompt with custom name
- Load saved prompts from dropdown menu
- Delete saved prompts
- Keyboard support (Enter to save)

## Technical Changes
- Added `SavedPrompt` interface to types
- Extended `ProjectSettings` with `savedPrompts` array
- DB migration to version 7 to support saved prompts
- Fixed DB version display in Settings

## Screenshots
<img width="1135" alt="Screenshot 2025-02-01 at 08 32 02" src="https://github.com/user-attachments/assets/e19c4f75-0d3e-426e-a5ef-8e7b70764d3e" />
