### PR TITLE
Fix inline code formatting to prevent line breaks

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,4 +132,12 @@
     -webkit-hyphens: auto;
     hyphens: auto;
   }
+  
+  .inline-code-fix code:not(pre code) {
+    display: inline !important;
+    white-space: normal !important;
+    word-break: normal !important;
+    line-height: inherit !important;
+    vertical-align: baseline !important;
+  }
 }

--- a/src/components/LlmChat/components/MessageContent.tsx
+++ b/src/components/LlmChat/components/MessageContent.tsx
@@ -46,7 +46,7 @@ export const MessageContentRenderer: React.FC<MessageContentProps> = ({
             }`}
           >
             <ReactMarkdown
-              className={`prose dark:prose-invert break-words max-w-full ${
+              className={`prose dark:prose-invert break-words max-w-full inline-code-fix ${
                 isUserMessage ? '[&_p]:!text-accent-foreground [&_code]:!text-accent-foreground' : ''
               }`}
               components={{
@@ -95,7 +95,7 @@ export const MessageContentRenderer: React.FC<MessageContentProps> = ({
                   const { className, children } = props;
                   const isInline = className?.includes('language-') === false;
                   return isInline ? (
-                    <code className="text-inherit whitespace-nowrap inline">
+                    <code className="text-inherit inline-block align-baseline">
                       {children}
                     </code>
                   ) : (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,8 +26,9 @@ module.exports = {
               overflow: 'auto',
             },
             code: {
-              wordBreak: 'break-word',
-              whiteSpace: 'pre-wrap',
+              wordBreak: 'normal',
+              whiteSpace: 'normal',
+              display: 'inline',
             },
             'code::before': {
               content: '""',


### PR DESCRIPTION
# Fix inline code formatting in Markdown

## Issue
Single backticks for inline code were causing unexpected line breaks in messages.

## Changes
- Modifying the inline code component to use inline-block and proper alignment
- Adding a custom CSS utility class that ensures inline code doesn't cause line breaks
- Updating the Tailwind typography configuration for code elements

## Screenshot
Left: Updated version (fixed)
Right: Previous version (broken with line breaks)
![Screenshot 2025-04-29 at 5 32 08 PM](https://github.com/user-attachments/assets/0e074911-aee1-40d9-a509-ffbb48066b12)

